### PR TITLE
Add MiddleDrag to list of macOS applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,7 @@
 - [Media Converter](http://media-converter.sourceforge.net/) - Simple (drag and drop) but advanced media conversion. [![Open-Source Software][OSS Icon]](https://sourceforge.net/p/media-converter/code/ci/master/tree/) ![Freeware][Freeware Icon]
 - [Menubar Colors](https://github.com/nvzqz/Menubar-Colors) - Convenient access to the system color panel. [![Open-Source Software][OSS Icon]](https://github.com/nvzqz/Menubar-Colors) ![Freeware][Freeware Icon]
 - [MenuMeters](http://member.ipmu.jp/yuji.tachikawa/MenuMetersElCapitan/) - A set of CPU, memory, disk, and network monitoring tools for macOS. [![Open-Source Software][OSS Icon]](https://github.com/yujitach/MenuMeters)
+- [MiddleDrag](https://github.com/NullPointerDepressiveDisorder/MiddleDrag) - Three-finger trackpad gestures for middle-click and middle-drag on macOS. [![Open-Source Software][OSS Icon]](https://github.com/NullPointerDepressiveDisorder/MiddleDrag) ![Freeware][Freeware Icon]
 - [MonitorControl](https://github.com/MonitorControl/MonitorControl) - Control your display's brightness and volume on your Mac as if it was a native Apple Display. Use Apple Keyboard keys or custom shortcuts. Shows the native macOS OSDs. [![Open-Source Software][OSS Icon]](https://github.com/MonitorControl/MonitorControl)
 - [Monodraw](http://monodraw.helftone.com/) - A powerful ASCII art editor.
 - [Mounty](http://enjoygineering.com/mounty/) - A tiny tool to re-mount write-protected NTFS volumes under macOS 10.9+ in read-write mode.


### PR DESCRIPTION
<!-- Thanks for contributing to awesome-macOS  -->

<!-- Please fill out the following: -->

0. [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
1. [x] Project URL: https://github.com/NullPointerDepressiveDisorder/MiddleDrag
2. [x] Why should this project be added: MiddleDrag is a free, open-source utility that enables middle-click and middle-drag via three-finger trackpad gestures. It fills a gap for Mac users who need middle-mouse functionality (especially CAD/3D software users) without the complexity of BetterTouchTool or the $8 cost of Middle. It's actively maintained, native Swift, and installs via Homebrew.
3. [x] End all descriptions with a full stop/period
4. [x] Entry is ordered alphabetically
5. [x] Appropriate icon(s) added if applicable (OSS, freeware)

<!--

Again, please read https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md if you didn't yet.

-->
