### PR TITLE
Add macOS Server Optimisation Toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,6 +373,7 @@
 - [Command Line Utilities Part 2](http://www.mitchchn.me/2014/and-eight-hundred-more/)
 - [EnvPane](https://github.com/hschmidt/EnvPane) - An preference pane for environment variables. [![Open-Source Software][OSS Icon]](https://github.com/hschmidt/EnvPane) ![Freeware][Freeware Icon]
 - [Glances](https://github.com/nicolargo/glances) - System monitoring tool that runs in terminal. [![Open-Source Software][OSS Icon]](https://github.com/nicolargo/glances) ![Freeware][Freeware Icon]
+- [macOS Server Optimisation Toolkit](https://github.com/hodorogandrei/macos-sequoia-optimisation) - Bash toolkit for optimising macOS Sequoia as a high-performance server by disabling consumer services, tuning network, and configuring power management. [![Open-Source Software][OSS Icon]](https://github.com/hodorogandrei/macos-sequoia-optimisation) ![Freeware][Freeware Icon]
 - [Thread on StackExchange](https://apple.stackexchange.com/questions/12161/os-x-terminal-must-have-utilities)
 
 


### PR DESCRIPTION
## Description

Adding [macOS Server Optimisation Toolkit](https://github.com/hodorogandrei/macos-sequoia-optimisation) to the **macOS Utilities** section.

## What it does

A Bash toolkit for optimising macOS Sequoia as a high-performance server:

- **Disables consumer services** via `launchctl disable` (reversible)
- **Tunes network stack** via sysctl (TCP buffers, window scaling)
- **Configures power management** for always-on server use
- **Fully reversible** — automatic backups with one-command restore
- **Dry-run mode** — preview all changes before applying

## Checklist

- [x] Open source (MIT license)
- [x] Free to use
- [x] Added in alphabetical order (after Glances, before Thread on StackExchange)
- [x] Follows existing format: `- [Name](link) - Description. [![OSS Icon]][source] ![Freeware Icon]`
- [x] Not a duplicate
- [x] Spelling and grammar checked

## Category

**macOS Utilities** — fits alongside other system utilities like Glances and EnvPane.