### PR TITLE
Add Capty to Graphics section

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@
 - [Affinity Photo](https://affinity.serif.com/en-us/photo/) - Raster image design tool, possible Adobe Photoshop alternative.
 - [GifCapture](https://github.com/onmyway133/GifCapture) - Record GIF screencasts. [![Open-Source Software][OSS Icon]](https://github.com/onmyway133/GifCapture)
 - [GIPHY Capture](https://itunes.apple.com/us/app/giphy-capture.-the-gif-maker/id668208984) - Capture and share GIFs on the desktop. ![Freeware][Freeware Icon]
+- [Capty](https://capty.app/) - Screen capture and recording app with built-in video editor, annotation tools, and wallpaper backgrounds.
 - [Image2icon](http://www.img2icnsapp.com) - Create and personalize icons from your pictures. ![Freeware][Freeware Icon]
 - [macSVG](https://macsvg.org/) - Design and edit SVG content for web, mobile, and animation. [![Open-Source Software][OSS Icon]](https://github.com/dsward2/macSVG) ![Freeware][Freeware Icon]
 - [OmniGraffle](https://www.omnigroup.com/omnigraffle) - An app for creating precise, beautiful graphics.


### PR DESCRIPTION
Hi! I'd like to suggest adding Capty to the Graphics section.

Capty is a macOS screen capture and recording app with:
- Area, window, and fullscreen capture
- Screen recording with audio and camera overlay
- Built-in video editor with zoom effects
- Annotation and markup tools
- Beautiful wallpaper backgrounds for screenshots
- OCR text capture

Website: https://capty.app