### PR TITLE
Add VPN Bypass to Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,7 @@
 - [Ukelele](http://scripts.sil.org/cms/scripts/page.php?site_id=nrsi&id=ukelele) - Unicode Keyboard Layout Editor. ![Freeware][Freeware Icon]
 - [Übersicht](http://tracesof.net/uebersicht/) - Run system commands and display their output on your desktop as widgets. [![Open-Source Software][OSS Icon]](https://github.com/felixhageloh/uebersicht) ![Freeware][Freeware Icon]
 - [The Unarchiver](https://theunarchiver.com/) - Unarchive many different kinds of archive files. ![Freeware][Freeware Icon]
+- [VPN Bypass](https://github.com/GeiserX/VPN-Bypass) - Menu bar app to route specific domains and services around your VPN, keeping business traffic secure while bypassing for personal services. [![Open-Source Software][OSS Icon]](https://github.com/GeiserX/VPN-Bypass) ![Freeware][Freeware Icon]
 - [Wineskin](https://github.com/Gcenx/WineskinServer) - Run Windows applications and games on your Mac. [![Open-Source Software][OSS Icon]](https://github.com/Gcenx/WineskinServer) ![Freeware][Freeware Icon]
 
 ### Video


### PR DESCRIPTION
## VPN Bypass

**Link:** https://github.com/GeiserX/VPN-Bypass
**License:** GPL-3.0 (Open Source, Free)
**macOS requirement:** 13.0 (Ventura) or later

A macOS menu bar app that automatically routes specific domains and services around your VPN, ensuring they use your regular internet connection.

### Features
- Menu bar app with quick access to status and controls
- Built-in service presets (Telegram, YouTube, WhatsApp, Spotify, Tailscale, etc.)
- Custom domain support
- Auto-apply routes when VPN connects
- Supports GlobalProtect, Cisco AnyConnect, OpenVPN, WireGuard, Fortinet, Zscaler, Cloudflare WARP, and more
- Route verification via ping tests
- Import/Export configuration
- Launch at Login

### Installation
Available via Homebrew: `brew install --cask vpn-bypass`

**Section:** Utilities (network/VPN utility, similar in nature to Gas Mask for hosts file management)