### PR TITLE
Add Stik to Productivity section

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@
 - [Rocket](http://matthewpalmer.net/rocket/) - Makes typing emoji faster and easier using Slack-style shortcuts. ![Freeware][Freeware Icon]
 - [SelfControl](https://selfcontrolapp.com/) - Block access to distracting websites. [![Open-Source Software][OSS Icon]](https://github.com/SelfControlApp/selfcontrol/) ![Freeware][Freeware Icon]
 - [Simplenote](https://simplenote.com/) - Simple cross-platform note taking app with cloud-based syncing. ![Freeware][Freeware Icon]
+- [Stik](https://stik.ink) - Instant thought capture for macOS. Global hotkey summons a post-it note, type and close. Notes stored as plain markdown files. [![Open-Source Software][OSS Icon]](https://github.com/0xMassi/stik_app) ![Freeware][Freeware Icon]
 - [Taskade](https://apps.apple.com/us/app/taskade-manage-anything/id1490048917/) - Real-time organization and task management tool.
 - [TaskPaper](https://www.taskpaper.com/) - Plain text to-do lists.
 - [Telephone](http://www.64characters.com/telephone/) - A SIP softphone. Make phone calls over the Internet or your company’s network. [![Open-Source Software][OSS Icon]](https://github.com/eofster/Telephone) ![Freeware][Freeware Icon]


### PR DESCRIPTION
## What is Stik?

[Stik](https://stik.ink) is an instant thought capture app for macOS. Press a global hotkey, a post-it note appears, type your thought, close it — done. Notes are stored as plain markdown files in `~/Documents/Stik/`.

- **Open source**: [github.com/0xMassi/stik_app](https://github.com/0xMassi/stik_app) (MIT license)
- **Free**: No account, no cloud, no subscription
- **Built with**: Tauri 2.0 (Rust + React)
- **Website**: [stik.ink](https://stik.ink)

## Checklist

- [x] Searched for duplicates — Stik is not currently listed
- [x] Entry placed alphabetically (between Simplenote and Taskade)
- [x] Includes Open-Source Software and Freeware badges
- [x] Category: Productivity