### PR TITLE
Add SaneApps — open-source macOS privacy utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@
 - [ForkLift](https://itunes.apple.com/us/app/forklift-file-manager-ftp/id412448059) - File Manager and FTP/SFTP/WebDAV/Amazon S3 client.
 - [Path Finder](http://www.cocoatech.com/pathfinder/) - A powerful dual-pane browser alternative to Finder.
 - [Quicklook-Plugins](https://github.com/sindresorhus/quick-look-plugins) - List of extra quicklook plugins to enable previewing more filetypes in the Finder.
+- [SaneClick](https://saneclick.com) - Finder extension with 51+ right-click context menu actions. [![Open-Source Software][OSS Icon]](https://github.com/sane-apps/SaneClick)
 - [TotalFinder](http://totalfinder.binaryage.com/) - A powerful alternative to Finder.
 - [XtraFinder](https://www.trankynam.com/xtrafinder/) - Adds useful features to Finder. ![Freeware][Freeware Icon]
 
@@ -221,6 +222,7 @@
 - [OmniFocus](https://www.omnigroup.com/omnifocus) - An incredible task management platform for Mac, iPad, and iPhone.
 - [OmniOutliner](https://www.omnigroup.com/omnioutliner/) - Perfect for collecting information, outlining ideas, adding structure to any sort of writing, and much more.
 - [Pandan](https://apps.apple.com/app/id1569600264) - Time awareness in your menu bar. ![Freeware][Freeware Icon]
+- [SaneClip](https://saneclip.com) - Clipboard manager with Touch ID protection and AES-256-GCM encryption. [![Open-Source Software][OSS Icon]](https://github.com/sane-apps/SaneClip)
 - [Paste](http://pasteapp.me) - The new way to copy & paste for Mac.
 - [PDF Archiver](https://github.com/JulianKahnert/PDF-Archiver) - A nice tool for tagging and archiving tasks. [![Open-Source Software][OSS Icon]](https://github.com/JulianKahnert/PDF-Archiver)
 - [PopClip](http://pilotmoon.com/popclip/) - Instantly copy & paste, access actions like search, spelling, dictionary and more.
@@ -259,6 +261,7 @@
 - [AppCleaner](http://freemacsoft.net/appcleaner/) - Uninstall your apps easily. ![Freeware][Freeware Icon]
 - [Artify](https://github.com/NghiaTranUIT/artify-macos) - A macOS X application for bringing dedicatedly 18th century Arts to everyone. [![Open-Source Software][OSS Icon]](https://github.com/NghiaTranUIT/artify-macos) ![Freeware][Freeware Icon]
 - [Bartender](https://www.macbartender.com/) - Organize your menu bar apps.
+- [SaneBar](https://sanebar.com) - Privacy-first menu bar manager with Touch ID lock and automation triggers. [![Open-Source Software][OSS Icon]](https://github.com/sane-apps/SaneBar)
 - [Batch Image Resizer](http://www.ironstarmedia.co.uk/resources/osx-image-resizer/) - Resize a large number of images quickly on your computer. ![Freeware][Freeware Icon]
 - [BeardedSpice](https://github.com/beardedspice/beardedspice) - Control web based media players with the media keys found on Mac keyboards. [![Open-Source Software][OSS Icon]](https://github.com/beardedspice/beardedspice) ![Freeware][Freeware Icon]
 - [BetterZip](https://macitbetter.com/) - A very capable and full-featured archive manager.
@@ -308,6 +311,7 @@
 - [Paparazzi](http://derailer.org/paparazzi/) - A small utility that makes screenshots of webpages. ![Freeware][Freeware Icon]
 - [Paragon NTFS](http://www.paragon-drivers.com/ntfs-mac/) - World fastest NTFS driver.
 - [Radio Silence](https://radiosilenceapp.com) - Simple to use firewall and network monitor.
+- [SaneHosts](https://sanehosts.com) - System-level ad/tracker blocker via /etc/hosts with 200+ curated blocklists. [![Open-Source Software][OSS Icon]](https://github.com/sane-apps/SaneHosts)
 - [Microsoft Remote Desktop Connection Client](https://itunes.apple.com/us/app/microsoft-remote-desktop/id715768417) - Remote Desktop Connection Client lets you connect from your Macintosh computer to a Windows-based computer.
 - [RDM](https://github.com/avibrazil/RDM) - Easily set Mac Retina display to higher unsupported resolutions. [![Open-Source Software][OSS Icon]](https://github.com/avibrazil/RDM)
 - [Site Sucker](http://ricks-apps.com/osx/sitesucker/) - Automatically download websites from the Internet.


### PR DESCRIPTION
## Added Apps

Adding 4 macOS utilities from the [SaneApps](https://saneapps.com) suite:

- **SaneBar** — Menu bar manager with Touch ID lock, Always-Hidden Zone, automation triggers
- **SaneClip** — Clipboard manager with Touch ID, AES-256-GCM encryption, sensitive data detection  
- **SaneHosts** — System-level ad/tracker blocker via /etc/hosts with 200+ curated blocklists
- **SaneClick** — Finder extension with 51+ right-click context menu actions

All apps are:
- Licensed under PolyForm Shield 1.0.0 (source code is completely free to use, modify, and learn from — the only restriction is you can't build a competing product)
- macOS native (Swift/SwiftUI)
- Privacy-first (zero telemetry, 100% on-device)
- $6.99 one-time purchase (or build from source)

**Disclosure:** I am the developer of these apps.