### PR TITLE
Add Hapi to Audio section

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@
 - [Audio Hijack](http://www.rogueamoeba.com/audiohijack/) - Record audio from any application like iTunes, Skype or Safari, or from hardware devices like microphones and mixers.
 - [Audio Profile Manager](https://apps.apple.com/us/app/audio-profile-manager/id1484150558?ls=1&mt=12) - Allows you to pin input/output devices for each particular combination of connected devices. May suppress HDMI displays from being chosen.
 - [BackgroundMusic](https://github.com/kyleneideck/BackgroundMusic) - Record system audio, control audio levels for individual apps, and automatically pauses your music player when other audio starts playing and unpauses it afterwards. [![Open-Source Software][OSS Icon]](https://github.com/kyleneideck/BackgroundMusic) ![Freeware][Freeware Icon]
+- [Hapi](https://speakhapi.com) - Privacy-first voice transcription and meeting recorder that processes everything locally on your Mac.
 - [krisp](https://krisp.ai/) - AI-powered app that removes background noise and echo from meetings leaving only human voice.
 - [Plug](https://plugformac.com) - Discover and listen to music from Hype Machine. [![Open-Source Software][OSS Icon]](https://github.com/wulkano/Plug) ![Freeware][Freeware Icon]
 - [Recordia](https://sindresorhus.com/recordia) - Record audio directly from the menu bar or with a global keyboard shortcut.


### PR DESCRIPTION
Privacy-first voice transcription and meeting recording app for macOS. Processes all audio locally without cloud dependencies.

<!-- Thanks for contributing to awesome-macOS  -->

<!-- Please fill out the following: -->
0. [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
1. [x] Project URL: https://speakhapi.com
2. [x] Why should this project be added: Privacy-first voice transcription and meeting recording app for macOS. Processes all audio locally without cloud dependencies. Features sub-3-second transcription latency, speaker diarization, custom hotkeys with auto-paste, and webhook integrations. Fills a gap for users seeking local alternatives to cloud-based transcription services.
3. [x] End all descriptions with a full stop/period
4. [x] Entry is ordered alphabetically
5. [x] Appropriate icon(s) added if applicable (OSS, freeware)
```

**Título del PR:**
```
Add Hapi to Audio section
```

**En el cuadro grande de descripción (si hay):**
```
Adding Hapi, a privacy-first voice transcription and meeting recorder for macOS that processes everything locally.

<!--

Again, please read https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md if you didn't yet.

-->
