### PR TITLE
Add native Command Book app to the Developers category

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@
 - [Anvil](http://anvilformac.com/) - Serve up static sites and Rack apps with simple URLs and zero configuration. ![Freeware][Freeware Icon]
 - [Base 2](http://menial.co.uk/base/) - A GUI for managing SQLite databases.
 - [CocoaRestClient](https://mmattozzi.github.io/cocoa-rest-client) - An app for testing REST endpoints. [![Open-Source Software][OSS Icon]](https://github.com/mmattozzi/cocoa-rest-client) ![Freeware][Freeware Icon]
-- [Command Book](https://commandbookapp.com) - A terminal companion for long-running terminal commands (freemium)
+- [Command Book](https://commandbookapp.com) - A terminal companion for long-running terminal commands (freemium).
 - [Cork](https://corkmac.app) - A fast, intuitive Homebrew GUI [![Open-Source Software][OSS Icon]](https://github.com/buresdv/Cork)
 - [Dash](https://kapeli.com/dash) - An API Documentation Browser and Code Snippet Manager.
 - [Decode](https://microcodingapps.com/products/decode.html) - Converts Xcode Interface Builder files (Xib and Storyboard files) to Swift source code.


### PR DESCRIPTION
<!-- Thanks for contributing to awesome-macOS  -->

<!-- Please fill out the following: -->

0. [X] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
1. [X] Project URL: https://commandbookapp.com
2. [X] Why should this project be added: It is a new native Swift/SwiftUI app build for developers and other people who can use some automation or use the terminal frequently.
3. [X] End all descriptions with a full stop/period
4. [X] Entry is ordered alphabetically
5. [X] Appropriate icon(s) added if applicable (OSS, freeware)

Thank you!
