### PR TITLE
Add GroAsk - macOS menu bar AI launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@
 - [Dropzone](https://aptonic.com/) - Create a popup grid of customizable actions that enhance productivity on your Mac.
 - [f.lux](https://justgetflux.com/) - Automatically adjust your computer screen to match lighting. ![Freeware][Freeware Icon]
 - [Fantastical](https://flexibits.com/fantastical) - Complete Calendar app replacement which uses natural language for creating events.
+- [GroAsk](https://groask.com/) - macOS menu bar AI launcher with quick access to multiple AI services via customizable hotkey.
 - [Hazel](https://www.noodlesoft.com/hazel.php) - Create rules to automatically keep your files organized.
 - [HazeOver](https://hazeover.com/) - Turn distractions down and focus on your current task.
 - [HyperDock](https://bahoom.com/hyperdock/) - Select individual application window.


### PR DESCRIPTION
## New Entry

- [GroAsk](https://groask.com/) - macOS menu bar AI launcher with quick access to multiple AI services via customizable hotkey.

### Checklist
- [x] I have read the Contribution Guidelines
- Project URL: https://groask.com
- Why should this project be added: GroAsk is a native macOS (AppKit) menu bar app that provides instant access to multiple AI services (ChatGPT, Claude, Gemini, Grok) via a global hotkey. It fills a unique niche as an AI launcher for macOS.
- [x] End all descriptions with a full stop/period
- [x] Entry is ordered alphabetically