### PR TITLE
Add BookShelves to E-Book Utilities section

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@
 
 ### E-Book Utilities
 
+- [BookShelves](https://getbookshelves.app/) - Ebook reader and library manager with 100,000+ free public domain books and iCloud sync. ![Freeware][Freeware Icon]
 - [Kindle App](http://www.amazon.com/gp/help/customer/display.html?nodeId=201246110) - Amazon Kindle App for macOS.
 
 


### PR DESCRIPTION
Added [BookShelves](https://getbookshelves.app/) to the E-Book Utilities section.

BookShelves is a native macOS/iOS ebook reader and library manager with:
- 100,000+ free public domain books (Standard Ebooks, Internet Archive)
- iCloud sync across Mac, iPhone, and iPad
- EPUB, PDF, MOBI, AZW3 support
- Free on the Mac App Store

[Mac App Store link](https://apps.apple.com/app/bookshelves-ebook-reader/id6756848973)

Entry added in alphabetical order.