### PR TITLE
Add SaneClick to Finder

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@
 - [ForkLift](https://itunes.apple.com/us/app/forklift-file-manager-ftp/id412448059) - File Manager and FTP/SFTP/WebDAV/Amazon S3 client.
 - [Path Finder](http://www.cocoatech.com/pathfinder/) - A powerful dual-pane browser alternative to Finder.
 - [Quicklook-Plugins](https://github.com/sindresorhus/quick-look-plugins) - List of extra quicklook plugins to enable previewing more filetypes in the Finder.
+- [SaneClick](https://saneclick.com) - Finder extension with 50+ ready-to-use right-click context menu actions. [![Open-Source Software][OSS Icon]](https://github.com/sane-apps/SaneClick)
 - [TotalFinder](http://totalfinder.binaryage.com/) - A powerful alternative to Finder.
 - [XtraFinder](https://www.trankynam.com/xtrafinder/) - Adds useful features to Finder. ![Freeware][Freeware Icon]
 


### PR DESCRIPTION
SaneClick is a Finder extension with 50+ ready-to-use right-click context menu actions for macOS.

Licensed under [PolyForm Shield 1.0.0](https://polyformproject.org/licenses/shield/1.0.0) — source code is completely free to use, modify, and learn from; the only restriction is you can't build a competing product. $6.99 one-time purchase, or [build from source](https://github.com/sane-apps/SaneClick#build-from-source) for free.

**Disclosure:** I am the developer of this app.