### PR TITLE
Add SaneHosts to Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,7 @@
 - [Radio Silence](https://radiosilenceapp.com) - Simple to use firewall and network monitor.
 - [Microsoft Remote Desktop Connection Client](https://itunes.apple.com/us/app/microsoft-remote-desktop/id715768417) - Remote Desktop Connection Client lets you connect from your Macintosh computer to a Windows-based computer.
 - [RDM](https://github.com/avibrazil/RDM) - Easily set Mac Retina display to higher unsupported resolutions. [![Open-Source Software][OSS Icon]](https://github.com/avibrazil/RDM)
+- [SaneHosts](https://sanehosts.com) - Native hosts file manager with 200+ curated blocklists and five protection levels. [![Open-Source Software][OSS Icon]](https://github.com/sane-apps/SaneHosts)
 - [Site Sucker](http://ricks-apps.com/osx/sitesucker/) - Automatically download websites from the Internet.
 - [ShiftIt](https://github.com/fikovnik/ShiftIt) - Managing windows size and position. [![Open-Source Software][OSS Icon]](https://github.com/fikovnik/ShiftIt) ![Freeware][Freeware Icon]
 - [SlowQuitApps](https://github.com/dteoh/SlowQuitApps) - Prevent accidental Cmd-Q. [![Open-Source Software][OSS Icon]](https://github.com/dteoh/SlowQuitApps) ![Freeware][Freeware Icon]


### PR DESCRIPTION
SaneHosts is a native macOS hosts file manager with 200+ curated blocklists and five protection levels.

Licensed under [PolyForm Shield 1.0.0](https://polyformproject.org/licenses/shield/1.0.0) — source code is completely free to use, modify, and learn from; the only restriction is you can't build a competing product. $6.99 one-time purchase, or [build from source](https://github.com/sane-apps/SaneHosts) for free.

**Disclosure:** I am the developer of this app.