### PR TITLE
Add Brood to Graphics

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@
 - [Acorn](https://secure.flyingmeat.com/acorn/) - A very Mac-like image editor with a comprehensive feature set.
 - [Affinity Designer](https://affinity.serif.com/en-us/designer/) - Vector image design tool, possible Adobe Illustrator alternative.
 - [Affinity Photo](https://affinity.serif.com/en-us/photo/) - Raster image design tool, possible Adobe Photoshop alternative.
+- [Brood](https://github.com/kevinshowkat/brood) - Reference-first AI image editing desktop for developers. [![Open-Source Software][OSS Icon]](https://github.com/kevinshowkat/brood)
 - [GifCapture](https://github.com/onmyway133/GifCapture) - Record GIF screencasts. [![Open-Source Software][OSS Icon]](https://github.com/onmyway133/GifCapture)
 - [GIPHY Capture](https://itunes.apple.com/us/app/giphy-capture.-the-gif-maker/id668208984) - Capture and share GIFs on the desktop. ![Freeware][Freeware Icon]
 - [Image2icon](http://www.img2icnsapp.com) - Create and personalize icons from your pictures. ![Freeware][Freeware Icon]


### PR DESCRIPTION
Adds Brood (https://github.com/kevinshowkat/brood) to the Graphics section as an open-source macOS image editing app.\n\n- Single-item PR\n- Alphabetical placement preserved\n- Description kept short, ending with a period