### PR TITLE
Add NameQuick to Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@
 - [Keytty](http://keytty.com) - Enables you to control your mouse with a few key strokes. Mouse Keys Alternative.
 - [LaunchBar](https://www.obdev.at/products/launchbar/index.html) - Start applications, navigate folders, manipulate files, control your Mac and much more just by using the keyboard.
 - [MeetingBar](https://meetingbar.onrender.com) - Your meetings in MacOS status bar [![Open-Source Software][OSS Icon]](https://github.com/leits/MeetingBar) ![Freeware][Freeware Icon]
+- [NameQuick](https://www.namequick.app) - AI-powered file renaming using GPT, Gemini, or local LLMs via Ollama.
 - [MenubarX](https://MenubarX.app) - A powerful menu bar browser.
 - [OmniFocus](https://www.omnigroup.com/omnifocus) - An incredible task management platform for Mac, iPad, and iPhone.
 - [OmniOutliner](https://www.omnigroup.com/omnioutliner/) - Perfect for collecting information, outlining ideas, adding structure to any sort of writing, and much more.


### PR DESCRIPTION
## Add NameQuick to Productivity

[NameQuick](https://www.namequick.app) is a macOS app that uses AI to automatically rename files with meaningful names. It supports OpenAI, Google Gemini, Anthropic, and local LLMs via Ollama for privacy-focused users.

Similar to Hazel (already listed in Productivity) which automates file organization, NameQuick automates file naming.

- **Platform:** macOS 14+
- **Built with:** Swift, SwiftUI (no Electron)
- **Free trial:** 14-day trial with managed AI credits included
- **Pricing:** One-time $19 or $9/month subscription

### Checklist

- [x] I have read the contribution guidelines
- [x] Project URL: https://www.namequick.app
- [x] This project should be added because it fills a gap in the Productivity section for AI-powered file management
- [x] Description ends with a period
- [x] Entry is in alphabetical order within the Productivity section