### PR TITLE
Add Notemac++ to list of code editors for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@
 - [CotEditor](https://coteditor.com) - Lightweight plain-text editor for macOS. [![Open-Source Software][OSS Icon]](https://github.com/coteditor/CotEditor/) ![Freeware][Freeware Icon]
 - [Emacs](https://www.emacswiki.org/emacs/EmacsForMacOS) - Port of Emacs to work as an macOS app. [![Open-Source Software][OSS Icon]](https://emacsformacosx.com/download/emacs-sources/) ![Freeware][Freeware Icon]
 - [MacVim](https://github.com/macvim-dev/macvim) - Vim, the text editor. [![Open-Source Software][OSS Icon]](https://github.com/macvim-dev/macvim) ![Freeware][Freeware Icon]
+- [Notemac++](https://github.com/sergioadevita/notemac-plus-plus) - A Notepad++-inspired code editor for macOS with 70+ language support, Git integration, and AI assistant. [![Open-Source Software][OSS Icon]](https://github.com/sergioadevita/notemac-plus-plus) ![Freeware][Freeware Icon]
 - [Nova](https://nova.app/) - The beautiful, fast, flexible, native Mac code editor from Panic.
 - [Sublime Text 3](http://www.sublimetext.com/) - The sophisticated text editor.
 - [TextMate](https://macromates.com/) - A graphical text editor. [![Open-Source Software][OSS Icon]](https://github.com/textmate/textmate)


### PR DESCRIPTION
Notemac++ is a free, open-source (MIT) code editor for macOS inspired by Notepad++. It features 70+ language syntax highlighting, built-in Git integration, an AI coding assistant, integrated terminal, macros, bookmarks, split views, and 7 themes. Built with Tauri + React.

GitHub: https://github.com/sergioadevita/notemac-plus-plus
Website: https://sergioadevita.github.io/notemac-plus-plus/

<!-- Thanks for contributing to awesome-macOS 🍎 -->

<!-- Please fill out the following: -->

0. [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
1. [x] Project URL: https://github.com/sergioadevita/notemac-plus-plus
2. [x] Why should this project be added: Notemac++ fills a gap for macOS users who want a Notepad++-like experience natively on Mac. It's a fully open-source, actively maintained code editor with features like 70+ language support, Git integration, AI coding assistant, macros, and an integrated terminal — all in a lightweight Tauri-based app.
3. [x] End all descriptions with a full stop/period
4. [x] Entry is ordered alphabetically
5. [x] Appropriate icon(s) added if applicable (OSS, freeware)

<!--

Again, please read https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md if you didn't yet.

-->