### PR TITLE
Add OpenPaw to Command Line Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,6 +365,7 @@
 - [m-cli](https://github.com/rgcr/m-cli) -  Swiss Army Knife for macOS.
 - [Mac-CLI](https://github.com/guarinogabriel/Mac-CLI) -  macOS command line tools for developers.
 - [mas](https://github.com/mas-cli/mas) - A CLI for the Mac App Store. [![Open-Source Software][OSS Icon]](https://github.com/mas-cli/mas) ![Freeware][Freeware Icon]
+- [OpenPaw](https://github.com/daxaur/openpaw) - Turn Claude Code into a personal assistant with 38 skills including email, calendar, Spotify, smart home, and more. [![Open-Source Software][OSS Icon]](https://github.com/daxaur/openpaw) ![Freeware][Freeware Icon]
 
 ## macOS Utilities
 


### PR DESCRIPTION
0. [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
1. [x] Project URL: https://github.com/daxaur/openpaw
2. [x] Why should this project be added: OpenPaw is an open-source CLI tool (`npx pawmode`) that turns Claude Code into a full personal assistant with 38 built-in skills — email, calendar, Spotify, smart home, Slack, GitHub, and more. It's written in TypeScript, MIT licensed, and designed specifically for macOS. It fits naturally in the Command Line Utilities section alongside other productivity-focused CLI tools.
3. [x] End all descriptions with a full stop/period
4. [x] Entry is ordered alphabetically
5. [x] Appropriate icon(s) added if applicable (OSS, freeware)