### PR TITLE
Add TailBar to Developers

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@
 - [Swiftify](https://objectivec2swift.com/#/xcode-extension/) - Objective-C to Swift code converter and Xcode & Finder extensions.
 - [TablePlus](https://tableplus.com/) - A modern, native GUI for multiple databases.
 - [Touch Bar Simulator](https://github.com/sindresorhus/touch-bar-simulator) - The macOS Touch Bar Simulator as a standalone app. [![Open-Source Software][OSS Icon]](https://github.com/sindresorhus/touch-bar-simulator) ![Freeware][Freeware Icon]
+- [TailBar](https://github.com/JungHoonGhae/TailBar) - Tailscale menu bar app for macOS. Manage servers, peers, and exit nodes. [![Open-Source Software][OSS Icon]](https://github.com/JungHoonGhae/TailBar) ![Freeware][Freeware Icon]
 - [Tower](https://www.git-tower.com/) - The most powerful Git client.
 - [Trailer](https://ptsochantaris.github.io/trailer/) - Configurable menubar Git notifications with accompanying native iOS app. [![Open-Source Software][OSS Icon]](https://github.com/ptsochantaris/trailer)
 - [Unused](https://jeffhodnett.github.io/Unused/) - An app for checking Xcode projects for unused resources. [![Open-Source Software][OSS Icon]](https://github.com/jeffhodnett/Unused) ![Freeware][Freeware Icon]


### PR DESCRIPTION
Added [TailBar](https://github.com/JungHoonGhae/TailBar) to the **Developers** section (alphabetical order).

Tailscale menu bar app for macOS. Manage servers, peers, and exit nodes.

- Native Swift/SwiftUI app (no Electron)
- Open source (MIT)
- Free
- Available via Homebrew