### PR TITLE
Add SaneClick to Finder

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@
 - [ForkLift](https://itunes.apple.com/us/app/forklift-file-manager-ftp/id412448059) - File Manager and FTP/SFTP/WebDAV/Amazon S3 client.
 - [Path Finder](http://www.cocoatech.com/pathfinder/) - A powerful dual-pane browser alternative to Finder.
 - [Quicklook-Plugins](https://github.com/sindresorhus/quick-look-plugins) - List of extra quicklook plugins to enable previewing more filetypes in the Finder.
+- [SaneClick](https://saneclick.com) - Finder extension with right-click actions for common file and folder workflows.
 - [TotalFinder](http://totalfinder.binaryage.com/) - A powerful alternative to Finder.
 - [XtraFinder](https://www.trankynam.com/xtrafinder/) - Adds useful features to Finder. ![Freeware][Freeware Icon]
 


### PR DESCRIPTION
0. [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md).
1. [x] Project URL: https://saneclick.com.
2. [x] Why should this project be added: Native macOS Finder extension that adds right-click actions for common file and folder tasks. A free Basic mode is available for maintainers to validate without purchase.
3. [x] End all descriptions with a full stop/period.
4. [x] Entry is ordered alphabetically.
5. [x] Appropriate icon(s) added if applicable (OSS, freeware).

Disclosure: I am the developer of this app.

If maintainers need Pro access for review, please email hi@saneapps.com and I will provide it.
