### PR TITLE
Add MiniClaw to Productivity section

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@
 - [LaunchBar](https://www.obdev.at/products/launchbar/index.html) - Start applications, navigate folders, manipulate files, control your Mac and much more just by using the keyboard.
 - [MeetingBar](https://meetingbar.onrender.com) - Your meetings in MacOS status bar [![Open-Source Software][OSS Icon]](https://github.com/leits/MeetingBar) ![Freeware][Freeware Icon]
 - [MenubarX](https://MenubarX.app) - A powerful menu bar browser.
+- [MiniClaw](https://miniclaw.bot) - macOS-native personal AI OS with 16+ plugins, persistent vector memory, and brain-inspired architecture. Built on OpenClaw. [![Open-Source Software][OSS Icon]](https://github.com/augmentedmike/miniclaw-os) ![Freeware][Freeware Icon]
 - [OmniFocus](https://www.omnigroup.com/omnifocus) - An incredible task management platform for Mac, iPad, and iPhone.
 - [OmniOutliner](https://www.omnigroup.com/omnioutliner/) - Perfect for collecting information, outlining ideas, adding structure to any sort of writing, and much more.
 - [Pandan](https://apps.apple.com/app/id1569600264) - Time awareness in your menu bar. ![Freeware][Freeware Icon]


### PR DESCRIPTION
## MiniClaw

[MiniClaw](https://miniclaw.bot) is a macOS-native personal AI OS with 16+ plugins, persistent vector memory, and a brain-inspired architecture.

- **GitHub**: https://github.com/augmentedmike/miniclaw-os
- **Apache 2.0 licensed**, open-source, free
- 16+ plugins (mc-board, mc-kb, mc-seo, mc-soul, mc-trust, mc-email, mc-designer, mc-human, etc.)
- Persistent vector memory with semantic search
- Local-first: all data stays on your Mac
- One-line install via Homebrew/npm
- Actively maintained

Added alphabetically in the Productivity section between MenubarX and OmniFocus.