### PR TITLE
Add TuringShot (기존 ZoomShot) to Productivity section

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@
 - [Telephone](http://www.64characters.com/telephone/) - A SIP softphone. Make phone calls over the Internet or your company’s network. [![Open-Source Software][OSS Icon]](https://github.com/eofster/Telephone) ![Freeware][Freeware Icon]
 - [TextExpander](https://smilesoftware.com/textexpander) - Create custom keyboard shortcuts for frequently-used text and pictures.
 - [Timing](https://timingapp.com/) - Automatic time and productivity tracking for Mac. Helps you stay on track with your work and ensures no billable hours get lost if you are billing hourly.
-- [ZoomShot](https://apps.apple.com/app/zoomshot-live-screen-effect/id6758536367) - Real-time screen zoom, cursor highlight, drawing, and text memo for macOS presentations and recordings.
+- [TuringShot (기존 ZoomShot)](https://apps.apple.com/app/zoomshot-live-screen-effect/id6758536367) - Real-time screen zoom, cursor highlight, drawing, and text memo for macOS presentations and recordings.
 
 
 ### Sharing Files


### PR DESCRIPTION
0. [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
1. [x] Project URL: https://apps.apple.com/app/zoomshot-live-screen-effect/id6758536367
2. [x] Why should this project be added: TuringShot (기존 ZoomShot) is a native macOS app for real-time screen zoom, cursor highlight, drawing, and text memo — designed for presentations and screen recordings. It fills a gap for users who need live annotation and zoom tools during presentations, similar to Presentify but with additional screen zoom and cursor highlight features.
3. [x] End all descriptions with a full stop/period.
4. [x] Entry is ordered alphabetically.
5. [x] Not an Electron app — native macOS application available on the Mac App Store (Freemium).