### PR TITLE
Add MuttonText - text expansion tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@
 - [LaunchBar](https://www.obdev.at/products/launchbar/index.html) - Start applications, navigate folders, manipulate files, control your Mac and much more just by using the keyboard.
 - [MeetingBar](https://meetingbar.onrender.com) - Your meetings in MacOS status bar [![Open-Source Software][OSS Icon]](https://github.com/leits/MeetingBar) ![Freeware][Freeware Icon]
 - [MenubarX](https://MenubarX.app) - A powerful menu bar browser.
+- [MuttonText](https://github.com/Muminur/MuttonText) - Free, privacy-focused text expansion tool with dynamic variables and sub-50ms latency. [![Open-Source Software][OSS Icon]](https://github.com/Muminur/MuttonText) ![Freeware][Freeware Icon]
 - [OmniFocus](https://www.omnigroup.com/omnifocus) - An incredible task management platform for Mac, iPad, and iPhone.
 - [OmniOutliner](https://www.omnigroup.com/omnioutliner/) - Perfect for collecting information, outlining ideas, adding structure to any sort of writing, and much more.
 - [Pandan](https://apps.apple.com/app/id1569600264) - Time awareness in your menu bar. ![Freeware][Freeware Icon]


### PR DESCRIPTION
## Add MuttonText

**Project:** [MuttonText](https://github.com/Muminur/MuttonText)

Open-source text expansion tool for macOS 12+. Keyword-triggered snippets with dynamic variables (clipboard, date/time, user input), customizable matching, and Beeftext compatibility.

- Sub-50ms latency, Rust backend with Tauri v2
- All data stays local — no cloud, no telemetry
- MIT licensed, free and open-source