### PR TITLE
Add SQLPro Studio to database management tools list

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@
 - [Quiver](http://happenapps.com/#quiver) - A delightful notebook for programmers that allows mixing rich text, code, markdown, LaTeX, and graphs.
 - [Sequel Ace](https://github.com/Sequel-Ace/Sequel-Ace) - A MySQL & MariaDB database manager. [![Open-Source Software][OSS Icon]](https://github.com/Sequel-Ace/Sequel-Ace) ![Freeware][Freeware Icon]
 - [Sequel Pro](http://www.sequelpro.com/) - A MySQL database manager. [![Open-Source Software][OSS Icon]](https://github.com/sequelpro/sequelpro) ![Freeware][Freeware Icon]
+- [SQLPro Studio](https://www.sqlprostudio.com/) - A simple, powerful database manager for MySQL, Postgres, Microsoft SQL Server, Oracle, and SQLite.
 - [SnippetsLab](https://www.renfei.org/snippets-lab/) - Manage and organise snippets of code.
 - [SourceTree](https://www.sourcetreeapp.com/) - A free Git & Mercurial client. ![Freeware][Freeware Icon]
 - [Swiftify](https://objectivec2swift.com/#/xcode-extension/) - Objective-C to Swift code converter and Xcode & Finder extensions.


### PR DESCRIPTION
Add SQLPro Studio to database management tools list

<!-- Thanks for contributing to awesome-macOS  -->

<!-- Please fill out the following: -->

0. [ ] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
1. [ ] Project URL:
2. [ ] Why should this project be added:
3. [ ] End all descriptions with a full stop/period
4. [ ] Entry is ordered alphabetically
5. [ ] Appropriate icon(s) added if applicable (OSS, freeware)

<!--

Again, please read https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md if you didn't yet.

-->
