### PR TITLE
Add HeyRobyn - Native Mac unified inbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@
 ### Email Utilities
 
 - [Airmail](http://airmailapp.com/) - Lightning fast email client designed for El Capitan.
+- [HeyRobyn](https://heyrobyn.ai) - Unified inbox for macOS — email, Slack, GitHub, and more in one native window with AI assistant.
 - [MailMate](https://freron.com/) - Advanced IMAP email client, featuring extensive keyboard control and Markdown support.
 - [Mailplane](https://mailplaneapp.com/) - A tightly integreted client for Google Mail, Inbox, Calender, and Contacts.
 


### PR DESCRIPTION
## HeyRobyn - Native Mac unified inbox

Added HeyRobyn to the Email Utilities section.

**What is HeyRobyn:**
- Native macOS unified inbox for email, Slack, and GitHub
- Built with SwiftUI (not Electron) for performance
- All data stays on-device for privacy
- Free during beta

**Website:** https://heyrobyn.ai

Fits perfectly in the Email Utilities category alongside Airmail, MailMate, and Mailplane.