### PR TITLE
Add HeyRobyn - Native Mac unified inbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@
 ### Email Utilities
 
 - [Airmail](http://airmailapp.com/) - Lightning fast email client designed for El Capitan.
+- [HeyRobyn](https://heyrobyn.ai/) - Native Mac unified inbox for email, Slack, and GitHub. ![Freeware][Freeware Icon]
 - [MailMate](https://freron.com/) - Advanced IMAP email client, featuring extensive keyboard control and Markdown support.
 - [Mailplane](https://mailplaneapp.com/) - A tightly integreted client for Google Mail, Inbox, Calender, and Contacts.
 


### PR DESCRIPTION
## Description

Added HeyRobyn to the Email Utilities section.

**HeyRobyn** is a native macOS unified inbox that brings together email, Slack, and GitHub notifications in one window. Built with SwiftUI (not Electron), all data stays on-device for privacy.

- **Website**: https://heyrobyn.ai
- **Category**: Email Utilities
- **Type**: Free software
- **Platform**: macOS (native)

## Changes
- Added HeyRobyn entry in alphabetical order between Airmail and MailMate
- Used appropriate Freeware icon marker
- Followed existing format and style conventions

Thanks for maintaining this awesome list!