### PR TITLE
Add HeyRobyn to Email Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@
 ### Email Utilities
 
 - [Airmail](http://airmailapp.com/) - Lightning fast email client designed for El Capitan.
+- [HeyRobyn](https://heyrobyn.ai/) - Native macOS unified inbox for email, Slack, and GitHub. Built with SwiftUI, privacy-first with all data on-device. ![Freeware][Freeware Icon]
 - [MailMate](https://freron.com/) - Advanced IMAP email client, featuring extensive keyboard control and Markdown support.
 - [Mailplane](https://mailplaneapp.com/) - A tightly integreted client for Google Mail, Inbox, Calender, and Contacts.
 


### PR DESCRIPTION
## Project Details

**HeyRobyn** is a native macOS email utility that provides a unified inbox for email, Slack, and GitHub.

### Key Features
- **Native SwiftUI**: Built as a true native macOS app (not Electron)
- **Unified Inbox**: Combines email, Slack messages, and GitHub notifications in one window
- **Privacy-First**: All data processed on-device, no cloud dependencies
- **Free**: Currently free during beta/launch phase

### Links
- Website: https://heyrobyn.ai
- Category: Email Utilities (alphabetically placed between Airmail and MailMate)

### Why This Addition?
HeyRobyn fits perfectly in the Email Utilities section as a modern, native macOS email and communication management tool. It complements the existing tools (Airmail, MailMate, Mailplane) by offering a unified inbox approach.

Thank you for maintaining this awesome list!