### PR TITLE
Add ClashX to Security

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,6 +427,7 @@ Ansible playbook to configure a development and desktop environment from a clean
 
 ## Security
 
+* [ClashX](https://clashx.tech/) - A rule-based proxy client for macOS with a simple UI. [![Open-Source Software][OSS Icon]](https://github.com/ClashX-Pro/ClashX) ![Freeware][Freeware Icon]
 * [GPG Suite](https://gpgtools.org/) - Full GPG toolkit with easy to understand GUI applications and Mail.app plugin. ![Freeware][Freeware Icon]
 * [LinkLiar](https://github.com/halo/LinkLiar) - Menu application written in Swift to help you spoof the MAC addresses of your Wi-Fi and Ethernet interfaces. [![Open-Source Software][OSS Icon]](https://github.com/halo/LinkLiar) ![Freeware][Freeware Icon]
 * [macchanger by acrogenesis](https://acrogenesis.com/macchanger/) - Easily change your MAC Address [![Open-Source Software][OSS Icon]](https://github.com/acrogenesis/macchanger) ![Freeware][Freeware Icon]


### PR DESCRIPTION
- [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
1. Project URL: https://clashx.tech/
2. Why should this project be added: ClashX is a well-maintained, open-source rule-based proxy client for macOS built on the Clash core. It features a clean native UI, supports advanced traffic routing with YAML-based rules, and is widely used in the macOS community. Source code is available at https://github.com/ClashX-Pro/ClashX.
3. [x] End all descriptions with a full stop/period.
4. [x] Entry is ordered alphabetically.
5. [x] Appropriate icon(s) added if applicable (OSS, freeware).