### PR TITLE
Add Nubo Email — native macOS email client

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@
 - [Airmail](http://airmailapp.com/) - Lightning fast email client designed for El Capitan.
 - [MailMate](https://freron.com/) - Advanced IMAP email client, featuring extensive keyboard control and Markdown support.
 - [Mailplane](https://mailplaneapp.com/) - A tightly integreted client for Google Mail, Inbox, Calender, and Contacts.
+- [Nubo Email](https://nubo.email) - Privacy-first email platform with calendar, drive, video meetings. Built on JMAP. Native macOS app.
 
 
 ### Finder


### PR DESCRIPTION
Adds [Nubo Email](https://nubo.email) — privacy-first email platform with native macOS support (Apple Silicon + Intel). JMAP protocol, calendar, drive, video meetings.