### PR TITLE
Add Fazm - AI computer agent for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@
 - [CloudClip](http://www.thinkbitz.com/cloudclip/) - Sync your clipboard between your Mac and your iOS devices. ![Freeware][Freeware Icon]
 - [Dropzone](https://aptonic.com/) - Create a popup grid of customizable actions that enhance productivity on your Mac.
 - [f.lux](https://justgetflux.com/) - Automatically adjust your computer screen to match lighting. ![Freeware][Freeware Icon]
+- [Fazm](https://fazm.ai) - Open-source, voice-controlled AI computer agent that controls your entire macOS desktop through natural language. [![Open-Source Software][OSS Icon]](https://github.com/m13v/fazm) ![Freeware][Freeware Icon]
 - [Fantastical](https://flexibits.com/fantastical) - Complete Calendar app replacement which uses natural language for creating events.
 - [Hazel](https://www.noodlesoft.com/hazel.php) - Create rules to automatically keep your files organized.
 - [HazeOver](https://hazeover.com/) - Turn distractions down and focus on your current task.


### PR DESCRIPTION
## Addition

Added [Fazm](https://fazm.ai/) to the **Productivity** section.

Fazm is a voice-first, open-source AI computer agent for macOS. It controls your entire desktop - clicking, typing, navigating browsers, writing code. Local-first architecture with on-device processing.

- Website: https://fazm.ai
- GitHub: https://github.com/m13v/fazm
- License: MIT