### PR TITLE
Add Promptzy — native macOS AI prompt manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,7 @@
 - [Telephone](http://www.64characters.com/telephone/) - A SIP softphone. Make phone calls over the Internet or your company’s network. [![Open-Source Software][OSS Icon]](https://github.com/eofster/Telephone) ![Freeware][Freeware Icon]
 - [TextExpander](https://smilesoftware.com/textexpander) - Create custom keyboard shortcuts for frequently-used text and pictures.
 - [Timing](https://timingapp.com/) - Automatic time and productivity tracking for Mac. Helps you stay on track with your work and ensures no billable hours get lost if you are billing hourly.
+- [Promptzy](https://promptzy.app) - Native macOS AI prompt manager with Cmd+Shift+P launcher, Markdown editor, and dynamic variable tokens. Free + one-time Pro.
 
 
 ### Sharing Files


### PR DESCRIPTION
Promptzy is a native macOS app that gives you a Cmd+Shift+P launcher for your AI prompt library. It stores prompts as plain Markdown files, supports dynamic tokens like `{{clipboard}}` and `{{date}}`, and pastes directly into any app. Free tier + $5 one-time Pro.

https://promptzy.app

Fits in the Productivity section alongside TextExpander.