### PR TITLE
Add Lockpaw to Security section

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,6 +429,7 @@ Ansible playbook to configure a development and desktop environment from a clean
 
 * [GPG Suite](https://gpgtools.org/) - Full GPG toolkit with easy to understand GUI applications and Mail.app plugin. ![Freeware][Freeware Icon]
 * [LinkLiar](https://github.com/halo/LinkLiar) - Menu application written in Swift to help you spoof the MAC addresses of your Wi-Fi and Ethernet interfaces. [![Open-Source Software][OSS Icon]](https://github.com/halo/LinkLiar) ![Freeware][Freeware Icon]
+* [Lockpaw](https://getlockpaw.com) - Locks the screen while letting background tasks, builds, and AI agents keep running. Native macOS menu bar app. [![Open-Source Software][OSS Icon]](https://github.com/sorkila/lockpaw) ![Freeware][Freeware Icon]
 * [macchanger by acrogenesis](https://acrogenesis.com/macchanger/) - Easily change your MAC Address [![Open-Source Software][OSS Icon]](https://github.com/acrogenesis/macchanger) ![Freeware][Freeware Icon]
 * [macchanger by shilch](https://github.com/shilch/macchanger/) - Change / spoof MAC address (random, custom and restore). [![Open-Source Software][OSS Icon]](https://github.com/shilch/macchanger)
 * [MIDAS](https://github.com/etsy/MIDAS) - Intrusion Detection Analysis System. [![Open-Source Software][OSS Icon]](https://github.com/etsy/MIDAS)


### PR DESCRIPTION
## Description

Add [Lockpaw](https://getlockpaw.com) to the Security section.

Lockpaw is a native macOS menu bar app that locks the screen while letting background tasks, builds, and AI agents keep running. It's open source and free.

- **Website:** https://getlockpaw.com
- **Source code:** https://github.com/sorkila/lockpaw
- **License:** Open source, free

The entry is placed in alphabetical order within the Security section and uses the standard formatting with the Open-Source Software and Freeware icons.