### PR TITLE
Add Promptzy - Free AI Prompt & Skills Manager & Markdown Editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@
 - [Emacs](https://www.emacswiki.org/emacs/EmacsForMacOS) - Port of Emacs to work as an macOS app. [![Open-Source Software][OSS Icon]](https://emacsformacosx.com/download/emacs-sources/) ![Freeware][Freeware Icon]
 - [MacVim](https://github.com/macvim-dev/macvim) - Vim, the text editor. [![Open-Source Software][OSS Icon]](https://github.com/macvim-dev/macvim) ![Freeware][Freeware Icon]
 - [Nova](https://nova.app/) - The beautiful, fast, flexible, native Mac code editor from Panic.
+- [Promptzy](https://promptzy.app) - Free AI prompt manager and lightweight Markdown editor for macOS. ![Freeware][Freeware Icon]
 - [Sublime Text 3](http://www.sublimetext.com/) - The sophisticated text editor.
 - [TextMate](https://macromates.com/) - A graphical text editor. [![Open-Source Software][OSS Icon]](https://github.com/textmate/textmate)
 - [VimR](http://vimr.org) - Vim, refined. [![Open-Source Software][OSS Icon]](https://github.com/qvacua/vimr) ![Freeware][Freeware Icon]


### PR DESCRIPTION
Adding [Promptzy](https://promptzy.app) to the Editors section.

Promptzy is a free, native macOS AI prompt & skills manager and lightweight Markdown editor. Stores content as plain Markdown files with collections, tags, global keyboard shortcut, and iCloud Sync.

**Website:** https://promptzy.app