### PR TITLE
Add Mocker - Docker-compatible container CLI for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,6 +369,7 @@
 - [m-cli](https://github.com/rgcr/m-cli) -  Swiss Army Knife for macOS.
 - [Mac-CLI](https://github.com/guarinogabriel/Mac-CLI) -  macOS command line tools for developers.
 - [mas](https://github.com/mas-cli/mas) - A CLI for the Mac App Store. [![Open-Source Software][OSS Icon]](https://github.com/mas-cli/mas) ![Freeware][Freeware Icon]
+- [Mocker](https://github.com/us/mocker) - Docker-compatible container management tool built natively on Apple's Containerization framework. [![Open-Source Software][OSS Icon]](https://github.com/us/mocker) ![Freeware][Freeware Icon]
 
 ## macOS Utilities
 


### PR DESCRIPTION
## What is Mocker?

[Mocker](https://github.com/us/mocker) is a Docker-compatible container management tool built natively on Apple's Containerization framework. It provides the same Docker CLI commands and flags (`mocker run`, `ps`, `stop`, `build`, `compose`, `stats`) running natively on macOS without Docker Desktop.

- **Open Source:** AGPL-3.0
- **Platform:** macOS (Apple Silicon)
- **Language:** Swift
- **GitHub:** https://github.com/us/mocker