### PR TITLE
Add Notch So Good

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,7 @@
 - [Noizio](http://noiz.io/) - Ambient sound equalizer for relaxation or productivity.
 - [Notational Velocity](http://notational.net/) - Store, retrieve and sync notes within a minimal GUI. [![Open-Source Software][OSS Icon]](https://github.com/scrod/nv/) ![Freeware][Freeware Icon]
 - [Noti](https://noti.center/) - Receive Android notifications on your mac (with PushBullet). [![Open-Source Software][OSS Icon]](https://github.com/jariz/Noti/) ![Freeware][Freeware Icon]
+- [Notch So Good](https://github.com/deepshal99/notch-so-good) - A pixel-art crab lives in your MacBook's notch and monitors Claude Code sessions with animations and smart notifications. [![Open-Source Software][OSS Icon]](https://github.com/deepshal99/notch-so-good) ![Freeware][Freeware Icon]
 - [Numi](http://numi.io/) - Beautiful calculator app. ![Freeware][Freeware Icon]
 - [OnyX](http://www.titanium.free.fr/) -  Multifunction utility to verify disks and files, run cleaning and system maintenance tasks, configure hidden options and more. ![Freeware][Freeware Icon]
 - [Paparazzi](http://derailer.org/paparazzi/) - A small utility that makes screenshots of webpages. ![Freeware][Freeware Icon]


### PR DESCRIPTION
I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md).

**Project URL:** https://github.com/deepshal99/notch-so-good

**Reason:** Notch So Good is a native macOS utility that turns your MacBook's notch into a Claude Code session monitor. A pixel-art crab (Chawd) watches your AI coding sessions with 13 idle animations, mouse-tracking eyes, and color-coded notifications. It hooks into Claude Code via URL scheme — no server, no polling. Open source, MIT licensed, installs with `npx notch-so-good`.

- [x] The description ends with a full stop/period.
- [x] The entry is ordered alphabetically within the Utilities category.
- [x] The appropriate OSS and Freeware icons are added.
- [x] I checked for duplicates before submitting.