### PR TITLE
Add "AI" related wording

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,14 +3,16 @@
 <!-- Please fill out the following: -->
 
 0. [ ] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
-1. [ ] Project URL:
-2. [ ] Why should this project be added:
-3. [ ] End all descriptions with a full stop/period
-4. [ ] Entry is ordered alphabetically
-5. [ ] Appropriate icon(s) added if applicable (OSS, freeware)
+1. [ ] I confirm that I have read and understood the sections about "AI"-adjacent software
+2. [ ] Project URL:
+3. [ ] Why should this project be added:
+4. [ ] End all descriptions with a full stop/period
+5. [ ] Entry is ordered alphabetically
+6. [ ] Appropriate icon(s) added if applicable (OSS, freeware)
 
 <!--
 
 Again, please read https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md if you didn't yet.
+If you don't fill out this template or replace it wholesale, your pull request will be closed without discussion.
 
 -->

--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -6,7 +6,7 @@ Please ensure your pull request adheres to the following guidelines:
 - Make an individual pull request for each suggestion.
 - Titles should be [capitalized](http://grammar.yourdictionary.com/capitalization/rules-for-capitalization-in-titles.html).
 - Keep descriptions short and simple.
-- Make sure your pull request (title, description) is truly descriptive and not redundant or self-evident (example: "It's a useful app"). Yes, we had such submissions. Fill out the template in the description box.
+- Make sure your pull request (title, description) is truly descriptive and not redundant or self-evident (example: "It's a useful app"). Yes, we had such submissions. Fill out the template in the description box. If you skip this step, your pull request will be closed.
 - End all descriptions with a full stop/period.
 - Order link titles alphabetically within each category.
 - Check your spelling and grammar. If you're not a native English speaker, make sure you triple-check or simply *ask the maintainers* for help. Nobody's perfect, you are welcome.
@@ -16,6 +16,7 @@ Please ensure your pull request adheres to the following guidelines:
 - Commercial applications should offer a free trial for maintainers to validate inclusion to the list. Free trials as part of a bundle/service like SetApp do not count.
 - Sensible new categories or improvements to the existing categorization are welcome. Please ask the maintainers if in doubt.
 - [No Electron](https://github.com/iCHAIT/awesome-macOS/pull/368) apps :no_good:
+- No AI prompt wrappers or software whose main purpose is interfacing with generative tools like LLMs, chatbots, code generation APIs and similar, including agents. Leveraging local, specialised ML models as part of a larger process is fine. Think image generation via prompt vs. manual image editing suite featuring a smart repair brush.
 - Do not include referrer query strings or other tracking mechanisms in the URL
 - Be prepared for criticism, don't feel entitled and keep an open mind.
 - If evident that you did not bother to read and follow these guidelines, your pull request may be closed immediately. You are welcome to a new attempt, given that in the meantime you did read and follow these guidelines.


### PR DESCRIPTION
Due to the increasing amount of "AI" adjacent pull requests, I've added clarifying language regarding the handling of such submissions. I advocate strongly for excluding them, just like Electron apps. One would think the reasons for rejecting generative slop are obvious enough at this point.

Additionally, due to an increase of pull requests that just skip the template entirely, I've added language that makes the consequences of lazy pull requests clear.

@iCHAIT, please review and merge if appropriate.