### PR TITLE
Add Mocker - Docker-compatible container CLI for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,6 +368,7 @@
 - [Awesome macOS Command Line](https://github.com/herrbischoff/awesome-osx-command-line) - Use your macOS terminal shell to do awesome things.
 - [m-cli](https://github.com/rgcr/m-cli) -  Swiss Army Knife for macOS.
 - [Mac-CLI](https://github.com/guarinogabriel/Mac-CLI) -  macOS command line tools for developers.
+- [Mocker](https://github.com/us/mocker) - Docker-compatible container CLI for macOS, built on Apple's Containerization framework. [![Open-Source Software][OSS Icon]](https://github.com/us/mocker) ![Freeware][Freeware Icon]
 - [mas](https://github.com/mas-cli/mas) - A CLI for the Mac App Store. [![Open-Source Software][OSS Icon]](https://github.com/mas-cli/mas) ![Freeware][Freeware Icon]
 
 ## macOS Utilities


### PR DESCRIPTION
[Mocker](https://github.com/us/mocker) is a Docker-compatible container CLI for macOS, built natively on Apple's Containerization framework. It provides full Docker CLI compatibility (`mocker run`, `mocker build`, `mocker compose`, etc.) without requiring Docker Desktop or a Linux VM.

- **Open source** (AGPL-3.0), written in Swift
- **Native macOS performance** using Apple's Virtualization and Containerization frameworks
- Supports 111 Docker CLI commands with full flag compatibility

Added to the "Command Line Utilities" section in alphabetical order.