### PR TITLE
Add TouchBridge — free Touch ID alternative for Macs without biometric sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@
 
 
 ### Productivity
-
+- [TouchBridge](https://github.com/HMAKT99/UnTouchID) - Use your phone's fingerprint to authenticate on any Mac. Free alternative to $199 Touch ID keyboard. [![Open-Source Software][OSS Icon]](https://github.com/HMAKT99/UnTouchID) ![Freeware][Freeware Icon]
 - [Alfred](https://www.alfredapp.com/) - Boosts your efficiency and productivity.
 - [BetterTouchTool](https://folivora.ai) - Configure gestures for mouse and actions for keyboard shortcuts.
 - [ClipMenu](http://www.clipmenu.com/) - ClipBoard History Manager. [![Open-Source Software][OSS Icon]](https://github.com/naotaka/ClipMenu) ![Freeware][Freeware Icon]


### PR DESCRIPTION
Title:
  Add TouchBridge — free Touch ID alternative for Macs without biometric sensor

 Description:
  <!-- Thanks for contributing to awesome-macOS 🍎 -->

  <!-- Please fill out the following: -->

  0. [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
  1. [x] Project URL: https://github.com/HMAKT99/UnTouchID
  2. [x] Why should this project be added: TouchBridge solves a real gap in macOS — Macs without Touch ID (Mac Mini, Mac Studio, Mac Pro, upcoming MacBook Neo) have no biometric auth option except buying a
  $199 Magic Keyboard. TouchBridge uses your phone's fingerprint/Face ID instead. Free, open source, 91 tests, works with iPhone, Android, Apple Watch, Wear OS, or any browser. No cloud dependency.
  3. [x] End all descriptions with a full stop/period
  4. [x] Entry is ordered alphabetically
  5. [x] Appropriate icon(s) added if applicable (OSS, freeware)
