### PR TITLE
Add Nudge to Window Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,7 @@
 - [Hammerspoon](http://www.hammerspoon.org/) - Extremely powerful scripting engine for macOS. [![Open-Source Software][OSS Icon]](https://github.com/Hammerspoon/hammerspoon) ![Freeware][Freeware Icon]
 - [Hummingbird](https://hummingbirdapp.site/) - Easily move and resize windows without mouse clicks, from anywhere within a window.
 - [Moom](https://manytricks.com/moom/) - Move and zoom windows, super light weight and customizable.
+- [Nudge](https://nudge.run) - Free, open-source window manager with keyboard shortcuts and drag-to-edge snapping. [![Open-Source Software][OSS Icon]](https://github.com/mikusnuz/nudge) ![Freeware][Freeware Icon]
 - [Phoenix](https://github.com/kasper/phoenix) - A lightweight window and app manager scriptable with JavaScript. [![Open-Source Software][OSS Icon]](https://github.com/Hammerspoon/hammerspoon) ![Freeware][Freeware Icon]
 - [Rectangle](https://rectangleapp.com/) - Easily organize windows without using a mouse. [![Open-Source Software][OSS Icon]](https://github.com/rxhanson/Rectangle) ![Freeware][Freeware Icon]
 - [Stay](https://cordlessdog.com/stay/) - Resize/position windows when displays change.


### PR DESCRIPTION
- [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
- [x] Project URL: https://nudge.run
- [x] Why should this project be added: Nudge is a free, open-source macOS window manager built with pure Swift/AppKit. It provides 19 window layouts via customizable keyboard shortcuts and drag-to-edge snapping, with multi-monitor support. Under 1MB, no Electron, no dependencies. MIT licensed.
- [x] End all descriptions with a full stop/period
- [x] Entry is ordered alphabetically
- [x] Appropriate icon(s) added if applicable (OSS, freeware)