### PR TITLE
Add RightLayout to Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,7 @@
 - [Radio Silence](https://radiosilenceapp.com) - Simple to use firewall and network monitor.
 - [Microsoft Remote Desktop Connection Client](https://itunes.apple.com/us/app/microsoft-remote-desktop/id715768417) - Remote Desktop Connection Client lets you connect from your Macintosh computer to a Windows-based computer.
 - [RDM](https://github.com/avibrazil/RDM) - Easily set Mac Retina display to higher unsupported resolutions. [![Open-Source Software][OSS Icon]](https://github.com/avibrazil/RDM)
+- [RightLayout](https://github.com/chernistry/RightLayout) - AI keyboard layout fixer — auto-corrects wrong layout (EN/RU/HE) as you type. Local CoreML, no cloud. [![Open-Source Software][OSS Icon]](https://github.com/chernistry/RightLayout) ![Freeware][Freeware Icon]
 - [SaneBar](https://sanebar.com) - Native menu bar manager with quick reveal controls and Touch ID lock.
 - [Site Sucker](http://ricks-apps.com/osx/sitesucker/) - Automatically download websites from the Internet.
 - [ShiftIt](https://github.com/fikovnik/ShiftIt) - Managing windows size and position. [![Open-Source Software][OSS Icon]](https://github.com/fikovnik/ShiftIt) ![Freeware][Freeware Icon]


### PR DESCRIPTION
## Add RightLayout

- [RightLayout](https://github.com/chernistry/RightLayout) - AI keyboard layout fixer — auto-corrects wrong layout (EN/RU/HE) as you type. Local CoreML, no cloud.

RightLayout is an open-source, free macOS utility that automatically detects and corrects text typed in the wrong keyboard layout. It supports English, Russian, and Hebrew, runs entirely on-device using CoreML, and requires no cloud connection.

Added to the **Utilities** section in alphabetical order (between RDM and SaneBar).