### PR TITLE
Add Core-Monitor to utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@
 - [ClipboardCleaner](https://github.com/Zuehlke/Clipboard_Cleaner) - Automatically removes text formatting from the clipboard. [![Open-Source Software][OSS Icon]](https://github.com/Zuehlke/Clipboard_Cleaner) ![Freeware][Freeware Icon]
 - [CommandQ](https://clickontyler.com/commandq/) - Never accidentally quit an app again.
 - [ControlPlane](http://www.controlplaneapp.com/) - Automate running tasks based on where you are or what you do. [![Open-Source Software][OSS Icon]](https://github.com/dustinrue/ControlPlane) ![Freeware][Freeware Icon]
+- [Core-Monitor](https://github.com/offyotto-sl3/Core-Monitor) - Open-source macOS control center with live monitoring, fan control, benchmarking, Touch Bar HUD, and CoreVisor virtualization. [![Open-Source Software][OSS Icon]](https://github.com/offyotto-sl3/Core-Monitor) ![Freeware][Freeware Icon]
 - [DaisyDisk](https://daisydiskapp.com/) - Analyze disk usage and free up disk space.
 - [Deliveries](http://junecloud.com/software/mac/deliveries.html) - Beautiful and simple package tracking.
 - [DisableMonitor](https://github.com/Eun/DisableMonitor) - Easily disable or enable a monitor on your Mac. [![Open-Source Software][OSS Icon]](https://github.com/Eun/DisableMonitor) ![Freeware][Freeware Icon]


### PR DESCRIPTION
0. [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
1. [x] Project URL: https://github.com/offyotto-sl3/Core-Monitor
2. [x] Why should this project be added: Core-Monitor is an open-source macOS control center that combines live system monitoring, fan control, benchmarking, Touch Bar HUD support, and CoreVisor virtualization in one native app.
3. [x] End all descriptions with a full stop/period
4. [x] Entry is ordered alphabetically
5. [x] Appropriate icon(s) added if applicable (OSS, freeware)
