### PR TITLE
Add Flock to Terminal section

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,7 @@
 
 ### Terminal
 
+- [Flock](https://github.com/Divagation/flock) - Native macOS multiplexer for running multiple Claude Code AI agent sessions in parallel with agent mode, themes, and prompt compression. [![Open-Source Software][OSS Icon]](https://github.com/Divagation/flock) ![Freeware][Freeware Icon]
 - [iTerm 2](https://www.iterm2.com/) - A terminal emulator. [![Open-Source Software][OSS Icon]](https://github.com/gnachman/iTerm2) ![Freeware][Freeware Icon]
 
 


### PR DESCRIPTION
## What is Flock?

[Flock](https://github.com/Divagation/flock) is a native macOS (Swift/AppKit) terminal multiplexer purpose-built for running multiple Claude Code AI agent sessions in parallel.

## Key Features

- **Agent mode** with kanban board for tracking parallel AI tasks
- **7 built-in themes** for visual session differentiation
- **Broadcast mode** to send commands to all sessions simultaneously
- **Wren prompt compression** for token savings
- **Usage tracking** with per-session analytics
- Free and open source, built with Swift/AppKit as a true native macOS app

## Changes

Added Flock to the **Terminal** section in alphabetical order, following the existing entry format with OSS and Freeware icons.