### PR TITLE
Add Dimly multi-monitor brightness control to the list of utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@
 - [ControlPlane](http://www.controlplaneapp.com/) - Automate running tasks based on where you are or what you do. [![Open-Source Software][OSS Icon]](https://github.com/dustinrue/ControlPlane) ![Freeware][Freeware Icon]
 - [DaisyDisk](https://daisydiskapp.com/) - Analyze disk usage and free up disk space.
 - [Deliveries](http://junecloud.com/software/mac/deliveries.html) - Beautiful and simple package tracking.
+- [Dimly](https://github.com/punshnut/macos-dimly) - Control brightness across mixed monitor setups from a single menu bar app. [![Open-Source Software][OSS Icon]](https://github.com/punshnut/macos-dimly) ![Freeware][Freeware Icon]
 - [DisableMonitor](https://github.com/Eun/DisableMonitor) - Easily disable or enable a monitor on your Mac. [![Open-Source Software][OSS Icon]](https://github.com/Eun/DisableMonitor) ![Freeware][Freeware Icon]
 - [Dozer](https://github.com/Mortennn/Dozer) - Hide MacOS menubar items. [![Open-Source Software][OSS Icon]](https://github.com/Mortennn/Dozer) ![Freeware][Freeware Icon]
 - [EtreCheck](http://etrecheck.com) - Output system information and configuration to get more informed help from Apple support professionals. ![Freeware][Freeware Icon]


### PR DESCRIPTION
**Why does this belong on the list?**

Dimly solves a common macOS pain point: controlling brightness uniformly across
mixed monitor setups - for example a MacBook display combined with one or more
external monitors that don't support native brightness control via macOS.

Most existing solutions are either paid (e.g. MonitorControl Pro) or lack
support for mixed/multi-display setups. Dimly fills this gap as a polished,
fully free and open-source menu bar utility.

- Free & open-source
- Supports mixed monitor setups (built-in + external)
- Menu bar native - no dock icon clutter
- No telemetry, no upsells
- Stable, feature-complete release

Fits well under the **Utilities** section alongside MonitorControl 
and similar tools.

Link: https://github.com/Punshnut/macos-dimly