### PR TITLE
Add ClawBox - sandboxed AI agent for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@
 ### Chat Clients
 
 - [ChitChat](https://github.com/stonesam92/ChitChat) - A native Mac app wrapper for WhatsApp Web. [![Open-Source Software][OSS Icon]](https://github.com/stonesam92/ChitChat) ![Freeware][Freeware Icon]
+- [ClawBox](https://github.com/coderkk1992/clawbox) - Run OpenClaw AI agent in a sandboxed Linux VM with a native macOS interface. [![Open-Source Software][OSS Icon]](https://github.com/coderkk1992/clawbox) ![Freeware][Freeware Icon]
 - [Telegram](https://itunes.apple.com/us/app/telegram/id747648890?mt=12) - A messaging app with a focus on speed and security, it’s super fast, simple and free. [![Open-Source Software][OSS Icon]](https://github.com/overtake/TelegramSwift) ![Freeware][Freeware Icon]
 - [Textual](https://www.codeux.com/textual/) - An Internet Relay Chat (IRC) client. [![Open-Source Software][OSS Icon]](https://github.com/Codeux-Software/Textual)
 


### PR DESCRIPTION
Adding [ClawBox](https://github.com/coderkk1992/clawbox) to the Chat Clients section.

ClawBox is a native macOS app that runs OpenClaw AI agent in a sandboxed Linux VM. Built with Tauri + React.

- Native macOS interface
- AI runs in isolated VM (via Lima)
- Supports Claude and GPT models
- Drag & drop file sharing
- Multiple agent personalities

Open source and free.