### PR TITLE
Added Certificate Ripper

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,6 +431,7 @@ Ansible playbook to configure a development and desktop environment from a clean
 
 ## Security
 
+* [Certificate Ripper](https://github.com/Hakky54/certificate-ripper) - Extract server certificates. [![Open-Source Software][OSS Icon]](https://github.com/Hakky54/certificate-ripper) ![Freeware][Freeware Icon]
 * [GPG Suite](https://gpgtools.org/) - Full GPG toolkit with easy to understand GUI applications and Mail.app plugin. ![Freeware][Freeware Icon]
 * [LinkLiar](https://github.com/halo/LinkLiar) - Menu application written in Swift to help you spoof the MAC addresses of your Wi-Fi and Ethernet interfaces. [![Open-Source Software][OSS Icon]](https://github.com/halo/LinkLiar) ![Freeware][Freeware Icon]
 * [Lockpaw](https://getlockpaw.com) - Locks the screen while letting background tasks, builds, and AI agents keep running. Native macOS menu bar app. [![Open-Source Software][OSS Icon]](https://github.com/sorkila/lockpaw) ![Freeware][Freeware Icon]


### PR DESCRIPTION
<!-- Thanks for contributing to awesome-macOS  -->

<!-- Please fill out the following: -->

0. [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
1. [x] I confirm that I have read and understood the sections about "AI"-adjacent software
2. [x] Project URL: https://github.com/Hakky54/certificate-ripper
3. [x] Why should this project be added: 

Certificate Ripper is a lightweight, open-source CLI tool for extracting server certificates from URLs across multiple protocols (HTTPS, WSS, FTPS, IMAPS, SMTPS, and more). It's a great addition to the list because:

Developer & security utility — useful for devops engineers, penetration testers, and anyone managing trust stores
macOS native support — available via Homebrew and provides native macOS binaries
No dependencies required — works without OpenSSL

5. [x] End all descriptions with a full stop/period
6. [x] Entry is ordered alphabetically
7. [x] Appropriate icon(s) added if applicable (OSS, freeware)

<!--

Again, please read https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md if you didn't yet.
If you don't fill out this template or replace it wholesale, your pull request will be closed without discussion.

-->
