### PR TITLE
Add Safari MCP to Developers section

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@
 - [PSequel](http://www.psequel.com/) - A PostgreSQL GUI tool. ![Freeware][Freeware Icon]
 - [QorumLogs](https://github.com/goktugyil/QorumLogs) - Swift Logging Utility for Xcode & Google Docs. [![Open-Source Software][OSS Icon]](https://github.com/goktugyil/QorumLogs) ![Freeware][Freeware Icon]
 - [Quiver](http://happenapps.com/#quiver) - A delightful notebook for programmers that allows mixing rich text, code, markdown, LaTeX, and graphs.
+- [Safari MCP](https://github.com/achiya-automation/safari-mcp) - Native Safari browser automation for AI agents. 80 tools via AppleScript + JavaScript. [![Open-Source Software][OSS Icon]](https://github.com/achiya-automation/safari-mcp) ![Freeware][Freeware Icon]
 - [Sequel Ace](https://github.com/Sequel-Ace/Sequel-Ace) - A MySQL & MariaDB database manager. [![Open-Source Software][OSS Icon]](https://github.com/Sequel-Ace/Sequel-Ace) ![Freeware][Freeware Icon]
 - [Sequel Pro](http://www.sequelpro.com/) - A MySQL database manager. [![Open-Source Software][OSS Icon]](https://github.com/sequelpro/sequelpro) ![Freeware][Freeware Icon]
 - [SnippetsLab](https://www.renfei.org/snippets-lab/) - Manage and organise snippets of code.


### PR DESCRIPTION
## Summary
- Adds [Safari MCP](https://github.com/achiya-automation/safari-mcp) to the Developers section
- Native Safari browser automation for AI agents on macOS — 80 tools via AppleScript + JavaScript
- Open-source (MIT), free, macOS-native

## Checklist
- [x] Entry follows existing format with OSS Icon and Freeware Icon
- [x] Alphabetically ordered (between "QorumLogs" and "Sequel Ace")
- [x] Project is open-source and macOS-specific