### PR TITLE
Add Kviskr to Audio section

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@
 - [Audio Profile Manager](https://apps.apple.com/us/app/audio-profile-manager/id1484150558?ls=1&mt=12) - Allows you to pin input/output devices for each particular combination of connected devices. May suppress HDMI displays from being chosen.
 - [BackgroundMusic](https://github.com/kyleneideck/BackgroundMusic) - Record system audio, control audio levels for individual apps, and automatically pauses your music player when other audio starts playing and unpauses it afterwards. [![Open-Source Software][OSS Icon]](https://github.com/kyleneideck/BackgroundMusic) ![Freeware][Freeware Icon]
 - [krisp](https://krisp.ai/) - AI-powered app that removes background noise and echo from meetings leaving only human voice.
+- [Kviskr](https://kviskr.no) - Menu bar app for speech-to-text using whisper.cpp with CoreML acceleration, specialized for Norwegian via NB-Whisper, with speaker diarization for meetings. ![Freeware][Freeware Icon]
 - [Plug](https://plugformac.com) - Discover and listen to music from Hype Machine. [![Open-Source Software][OSS Icon]](https://github.com/wulkano/Plug) ![Freeware][Freeware Icon]
 - [Recordia](https://sindresorhus.com/recordia) - Record audio directly from the menu bar or with a global keyboard shortcut.
 - [VOX Player](https://coppertino.com/vox/mac) - Play numerous lossy and lossless audio formats.


### PR DESCRIPTION
## Summary
- Add [Kviskr](https://kviskr.no) to the Audio section in alphabetical order
- Kviskr is a free macOS menu bar app for speech-to-text using whisper.cpp with CoreML acceleration
- Specialized for Norwegian via NB-Whisper from NbAiLab, with speaker diarization for meetings
- macOS 14+, Apple Silicon

## Checklist
- [x] Added in alphabetical order within the Audio section
- [x] Follows the existing format: `- [Name](url) - Description. ![Freeware][Freeware Icon]`
- [x] Freeware icon included (the app is free)