### PR TITLE
Add Revu - local-first macOS spaced repetition app

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@
 - [Presentify](https://presentify.compzets.com) - Annotate anything on screen, be it, images, pdfs, videos, code, etc.
 - [Qbserve](https://qotoqot.com/qbserve/) - Automatic time and project tracking, timesheets, invoicing, and real-time productivity feedback.
 - [Quicksilver](https://qsapp.com/) - Control your Mac quickly and elegantly. [![Open-Source Software][OSS Icon]](https://github.com/quicksilver/Quicksilver) ![Freeware][Freeware Icon]
+- [Revu](https://revu.cards/) - Local-first spaced repetition app with FSRS scheduling, Anki import, study guides, exams, and forecasting. [![Open-Source Software][OSS Icon]](https://github.com/JuliusBrussee/revu-swift)
 - [Rocket](http://matthewpalmer.net/rocket/) - Makes typing emoji faster and easier using Slack-style shortcuts. ![Freeware][Freeware Icon]
 - [SelfControl](https://selfcontrolapp.com/) - Block access to distracting websites. [![Open-Source Software][OSS Icon]](https://github.com/SelfControlApp/selfcontrol/) ![Freeware][Freeware Icon]
 - [Simplenote](https://simplenote.com/) - Simple cross-platform note taking app with cloud-based syncing. ![Freeware][Freeware Icon]


### PR DESCRIPTION
## Summary

- Adds [Revu](https://revu.cards/) to the Productivity section
- Revu is a local-first spaced repetition app for macOS with FSRS scheduling, Anki import, study guides, exams, and forecasting
- Built natively with SwiftUI (not Electron)
- Open source under GPL-3.0: https://github.com/JuliusBrussee/revu-swift