### PR TITLE
Add Revu

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@
 - [Presentify](https://presentify.compzets.com) - Annotate anything on screen, be it, images, pdfs, videos, code, etc.
 - [Qbserve](https://qotoqot.com/qbserve/) - Automatic time and project tracking, timesheets, invoicing, and real-time productivity feedback.
 - [Quicksilver](https://qsapp.com/) - Control your Mac quickly and elegantly. [![Open-Source Software][OSS Icon]](https://github.com/quicksilver/Quicksilver) ![Freeware][Freeware Icon]
+- [Revu](https://revu.cards/) - Local-first spaced repetition app with FSRS scheduling, Anki import, study guides, exams, and workload forecasting. [![Open-Source Software][OSS Icon]](https://github.com/JuliusBrussee/revu-swift) ![Freeware][Freeware Icon]
 - [Rocket](http://matthewpalmer.net/rocket/) - Makes typing emoji faster and easier using Slack-style shortcuts. ![Freeware][Freeware Icon]
 - [SelfControl](https://selfcontrolapp.com/) - Block access to distracting websites. [![Open-Source Software][OSS Icon]](https://github.com/SelfControlApp/selfcontrol/) ![Freeware][Freeware Icon]
 - [Simplenote](https://simplenote.com/) - Simple cross-platform note taking app with cloud-based syncing. ![Freeware][Freeware Icon]


### PR DESCRIPTION
<!-- Thanks for contributing to awesome-macOS  -->

<!-- Please fill out the following: -->

0. [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
1. [x] I confirm that I have read and understood the sections about "AI"-adjacent software
2. [x] Project URL: https://github.com/JuliusBrussee/revu-swift
3. [x] Why should this project be added: Revu is a native macOS study app built with Swift and SwiftUI. It uses FSRS spaced repetition scheduling, supports Anki import (.apkg/.colpkg), and provides study guides, exams, and workload forecasting. It is free, open source (GPL-3.0), and fully local-first with no account or network dependency. Source: https://github.com/JuliusBrussee/revu-swift
4. [x] End all descriptions with a full stop/period
5. [x] Entry is ordered alphabetically
6. [x] Appropriate icon(s) added if applicable (OSS, freeware)