### PR TITLE
Add Zipic - Free image compression tool for Mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@
 - [Sketch](http://www.sketchapp.com/) - Hybrid vector/bitmap layout application, especially useful for UI, web and mobile design.
 - [Sketch Toolbox](http://sketchtoolbox.com/) - A super simple plugin manager for Sketch. [![Open-Source Software][OSS Icon]](https://github.com/buzzfeed/Sketch-Toolbox)
 - [xScope](http://xscopeapp.com/) - Tools for measuring, inspecting and testing on-screen graphics and layouts.
+- [Zipic](https://zipic.app) - Free image compression tool for Mac. Compress JPEG, PNG, WebP, HEIC, AVIF and more with batch processing, folder monitoring, and lossless optimization. ![Freeware][Freeware Icon]
 
 
 ### News Readers


### PR DESCRIPTION
Adding [Zipic](https://zipic.app) to the Graphics section.

**Zipic** is a free image compression tool for macOS that supports 12 formats including JPEG, PNG, WebP, HEIC, AVIF, TIFF, ICNS, SVG, PDF, and JPEG-XL. Key features include:

- Batch processing with folder monitoring auto-compression
- Privacy-first: fully local processing, no cloud uploads
- Native macOS integration with Raycast, Shortcuts, and AppIntents
- Up to 90%+ compression ratios while maintaining visually lossless quality
- Compression presets for different optimization workflows

Website: https://zipic.app
Documentation: https://docs.zipic.app