### PR TITLE
Add DockWright - Native macOS AI assistant

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,7 @@
 - [DaisyDisk](https://daisydiskapp.com/) - Analyze disk usage and free up disk space.
 - [Deliveries](http://junecloud.com/software/mac/deliveries.html) - Beautiful and simple package tracking.
 - [DisableMonitor](https://github.com/Eun/DisableMonitor) - Easily disable or enable a monitor on your Mac. [![Open-Source Software][OSS Icon]](https://github.com/Eun/DisableMonitor) ![Freeware][Freeware Icon]
+- [DockWright](https://github.com/AdelElo13/DockWright-MacOS-Agent) - Native macOS AI assistant with screen awareness, voice control, 30 system tools, and 9 LLM providers.
 - [Dozer](https://github.com/Mortennn/Dozer) - Hide MacOS menubar items. [![Open-Source Software][OSS Icon]](https://github.com/Mortennn/Dozer) ![Freeware][Freeware Icon]
 - [EtreCheck](http://etrecheck.com) - Output system information and configuration to get more informed help from Apple support professionals. ![Freeware][Freeware Icon]
 - [Equinox](https://equinoxmac.com) - Create macOS dynamic wallpapers. [![Open-Source Software][OSS Icon]](https://github.com/rlxone/Equinox) ![Freeware][Freeware Icon]


### PR DESCRIPTION
DockWright is a native macOS AI assistant built in Swift with zero dependencies. Features: screen awareness, voice control, 30 system tools, 9 LLM providers. https://dockwright.com