### PR TITLE
Add Tight Studio to Video section

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,7 @@
 - [ScreenFlow](http://www.telestream.net/screenflow/) - Screencasting and video editing software.
 - [Subler](https://bitbucket.org/galad87/subler/wiki/Home) - Mux and tag MP4 files. [![Open-Source Software][OSS Icon]](https://bitbucket.org/galad87/subler/wiki/Home) ![Freeware][Freeware Icon]
 - [Subtitlr](http://lucija.frkovic.me/Subtitlr/) - Drag and drop subititle download utility. [![Open-Source Software][OSS Icon]](https://github.com/spilja/Subtitlr/tree/master)
+- [Tight Studio](https://tight.studio/) - Screen recorder and video editor that produces polished demos, tutorials, and presentations.
 
 ### Window Management
 


### PR DESCRIPTION
## Summary

Adding [Tight Studio](https://tight.studio/) to the Video section.

Tight Studio is a macOS screen recorder and video editor designed to produce polished product demos, tutorials, and presentations. It features automatic zoom effects, captions, and background customization - all in a native Mac app. It follows a freemium pricing model.

The entry is placed in alphabetical order after Subtitlr.