### PR TITLE
Add Muxy to Terminal section

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@
 ### Terminal
 
 - [iTerm 2](https://www.iterm2.com/) - A terminal emulator. [![Open-Source Software][OSS Icon]](https://github.com/gnachman/iTerm2) ![Freeware][Freeware Icon]
+- [Muxy](https://github.com/muxy-app/muxy) - A native macOS terminal multiplexer built with SwiftUI and libghostty. [![Open-Source Software][OSS Icon]](https://github.com/muxy-app/muxy) ![Freeware][Freeware Icon]
 
 
 ### Utilities


### PR DESCRIPTION
0. [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
1. [x] I confirm that I have read and understood the sections about "AI"-adjacent software
2. [x] Project URL: https://github.com/muxy-app/muxy
3. [x] Why should this project be added: Muxy is a native macOS terminal multiplexer built with SwiftUI and libghostty (Metal-accelerated rendering). It is a genuinely native Mac app — no Electron, no web views — offering project-based workspaces, split panes, and tab management. There is currently no terminal multiplexer listed in the awesome-macOS list, and Muxy fills that gap.
4. [x] End all descriptions with a full stop/period
5. [x] Entry is ordered alphabetically
6. [x] Appropriate icon(s) added if applicable (OSS, freeware)