### PR TITLE
Add Shake It On to Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,7 @@
 - [RDM](https://github.com/avibrazil/RDM) - Easily set Mac Retina display to higher unsupported resolutions. [![Open-Source Software][OSS Icon]](https://github.com/avibrazil/RDM)
 - [SaneBar](https://sanebar.com) - Native menu bar manager with quick reveal controls and Touch ID lock.
 - [Site Sucker](http://ricks-apps.com/osx/sitesucker/) - Automatically download websites from the Internet.
+- [Shake It On](https://shakeiton.app?ref=awesome-macos) - Menu bar app that keeps your Mac awake with organic mouse movement and smart conditions for CPU, apps, Wi-Fi, display, and more.
 - [ShiftIt](https://github.com/fikovnik/ShiftIt) - Managing windows size and position. [![Open-Source Software][OSS Icon]](https://github.com/fikovnik/ShiftIt) ![Freeware][Freeware Icon]
 - [SlowQuitApps](https://github.com/dteoh/SlowQuitApps) - Prevent accidental Cmd-Q. [![Open-Source Software][OSS Icon]](https://github.com/dteoh/SlowQuitApps) ![Freeware][Freeware Icon]
 - [SmartCapsLock](https://kishanbagaria.com/smartcapslock/) - Makes the Caps Lock key smarter, so that when the key accidentally gets activated and you START YELLING even though you don't want to, you can just select the yelling-text and press the key again to instantly fix its case instead of typing everything all over again.


### PR DESCRIPTION
Adding [Shake It On](https://shakeiton.app) to the Utilities section.

Shake It On is a macOS menu bar app that keeps your Mac awake by generating organic mouse movement to reset the system idle timer. Features smart activation conditions (CPU, apps, Wi-Fi, display, audio) and pause triggers (battery, camera, Focus, lock). Works with corporate MDM and remote desktop. $9.99 one-time, no subscription.