### PR TITLE
Add SnapHotkey to Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@
 - [Rocket](http://matthewpalmer.net/rocket/) - Makes typing emoji faster and easier using Slack-style shortcuts. ![Freeware][Freeware Icon]
 - [SelfControl](https://selfcontrolapp.com/) - Block access to distracting websites. [![Open-Source Software][OSS Icon]](https://github.com/SelfControlApp/selfcontrol/) ![Freeware][Freeware Icon]
 - [Simplenote](https://simplenote.com/) - Simple cross-platform note taking app with cloud-based syncing. ![Freeware][Freeware Icon]
+- [SnapHotkey](https://snaphotkey.com) - Assign keyboard shortcuts to specific apps for instant switching with left/right modifier key distinction and show/hide toggle.
 - [Taskade](https://apps.apple.com/us/app/taskade-manage-anything/id1490048917/) - Real-time organization and task management tool.
 - [TaskPaper](https://www.taskpaper.com/) - Plain text to-do lists.
 - [Telephone](http://www.64characters.com/telephone/) - A SIP softphone. Make phone calls over the Internet or your company’s network. [![Open-Source Software][OSS Icon]](https://github.com/eofster/Telephone) ![Freeware][Freeware Icon]


### PR DESCRIPTION
## Summary

Add [SnapHotkey](https://snaphotkey.com) to the Productivity section.

SnapHotkey is a native macOS app for hotkey-to-app mapping. It lets users assign keyboard shortcuts to specific apps for instant switching, with support for left/right modifier key distinction, show/hide toggle, and same-app multi-window cycling and deep open(open with parameters or specific path).