### PR TITLE
Add MacSift to Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,7 @@
 - [MacDown](http://macdown.uranusjr.com/) - Markdown editor. [![Open-Source Software][OSS Icon]](https://github.com/MacDownApp/macdown) ![Freeware][Freeware Icon]
 - [Mackup](https://github.com/lra/mackup) - Keep your application settings in sync. [![Open-Source Software][OSS Icon]](https://github.com/lra/mackup) ![Freeware][Freeware Icon]
 - [MacPass](https://macpass.github.io/) - Password Manager. [![Open-Source Software][OSS Icon]](https://github.com/MacPass/MacPass) ![Freeware][Freeware Icon]
+- [MacSift](https://github.com/Lcharvol/MacSift) - Transparent disk cleaner for macOS 26 Tahoe. Groups files by the app that owns them, always moves to Trash — never hard-deletes. [![Open-Source Software][OSS Icon]](https://github.com/Lcharvol/MacSift) ![Freeware][Freeware Icon]
 - [Media Converter](http://media-converter.sourceforge.net/) - Simple (drag and drop) but advanced media conversion. [![Open-Source Software][OSS Icon]](https://sourceforge.net/p/media-converter/code/ci/master/tree/) ![Freeware][Freeware Icon]
 - [Menubar Colors](https://github.com/nvzqz/Menubar-Colors) - Convenient access to the system color panel. [![Open-Source Software][OSS Icon]](https://github.com/nvzqz/Menubar-Colors) ![Freeware][Freeware Icon]
 - [MenuMeters](http://member.ipmu.jp/yuji.tachikawa/MenuMetersElCapitan/) - A set of CPU, memory, disk, and network monitoring tools for macOS. [![Open-Source Software][OSS Icon]](https://github.com/yujitach/MenuMeters)


### PR DESCRIPTION
Adding **[MacSift](https://github.com/Lcharvol/MacSift)** to the Utilities section — a transparent macOS disk cleaner that groups files by the app that owns them and always moves to Trash, never hard-deletes.

### Why it fits

- **Open source** (MIT licensed) — source code is linked from the entry, so both the OSS and freeware badges apply, consistent with neighbors like Mackup and MacPass.
- **Native SwiftUI** for macOS 26 Tahoe, using the new Liquid Glass API. ~4k lines, fully inspectable — the cleaning engine is [120 lines you can audit in one sitting](https://github.com/Lcharvol/MacSift/blob/main/MacSift/Services/CleaningEngine.swift).
- **Distinct from existing entries**: *DaisyDisk* and *OnyX* already appear in the list but they're disk analyzers / maintenance tools. MacSift's niche is "what's here and why is it here, grouped by owning app, with every action auditable and reversible". Dry-run is on by default for new installs; nothing is permanently deleted.

### Alphabetical order

Inserted between **Mackup** and **Media Converter**, preserving the existing ordering in Utilities.

### Quality checks

- Release binary is [published on GitHub Releases](https://github.com/Lcharvol/MacSift/releases/latest) (latest is v0.2.8).
- 191 tests across 33 suites, green on the current release.
- Repo has both a [README](https://github.com/Lcharvol/MacSift#readme) and a [SECURITY.md](https://github.com/Lcharvol/MacSift/blob/main/SECURITY.md) with a documented threat model and reporting channel.
- Landing page at [lcharvol.github.io/MacSift](https://lcharvol.github.io/MacSift/).

Happy to adjust the description wording or the category if you'd prefer it somewhere else. Thanks for maintaining this list!