### PR TITLE
Add gistgrep to Command Line Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,6 +370,7 @@
 - [Mac-CLI](https://github.com/guarinogabriel/Mac-CLI) -  macOS command line tools for developers.
 - [Mocker](https://github.com/us/mocker) - Docker-compatible container CLI for macOS, built on Apple's Containerization framework. [![Open-Source Software][OSS Icon]](https://github.com/us/mocker) ![Freeware][Freeware Icon]
 - [mas](https://github.com/mas-cli/mas) - A CLI for the Mac App Store. [![Open-Source Software][OSS Icon]](https://github.com/mas-cli/mas) ![Freeware][Freeware Icon]
+- [gistgrep](https://github.com/mattheworiordan/gistgrep) - Search your GitHub gists locally with fzf and on-device Apple Intelligence summaries. [![Open-Source Software][OSS Icon]](https://github.com/mattheworiordan/gistgrep) ![Freeware][Freeware Icon]
 
 ## macOS Utilities
 


### PR DESCRIPTION
Adds **gistgrep**, a macOS CLI for searching your own GitHub gists locally, under *Command Line Utilities*.

- Local mirror + incremental sync, sub-100ms warm search
- fzf-based preview pane with ranked results
- On-device AI summaries via Apple Intelligence (`FoundationModels`), no API keys, no network
- MIT licensed, install via `brew install mattheworiordan/tap/gistgrep`

![gistgrep demo](https://github.com/user-attachments/assets/7b56257a-b4c2-461c-8615-901b54421b32)

Repo: https://github.com/mattheworiordan/gistgrep