### PR TITLE
Add Clippy to Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@
 - [Alfred](https://www.alfredapp.com/) - Boosts your efficiency and productivity.
 - [BetterTouchTool](https://folivora.ai) - Configure gestures for mouse and actions for keyboard shortcuts.
 - [ClipMenu](http://www.clipmenu.com/) - ClipBoard History Manager. [![Open-Source Software][OSS Icon]](https://github.com/naotaka/ClipMenu) ![Freeware][Freeware Icon]
+- [Clippy](https://github.com/yarasaa/Clippy) - Smart clipboard manager with content-aware previews, AI transformations, a built-in screenshot editor, and file converter. [![Open-Source Software][OSS Icon]](https://github.com/yarasaa/Clippy) ![Freeware][Freeware Icon]
 - [CloudClip](http://www.thinkbitz.com/cloudclip/) - Sync your clipboard between your Mac and your iOS devices. ![Freeware][Freeware Icon]
 - [Dropzone](https://aptonic.com/) - Create a popup grid of customizable actions that enhance productivity on your Mac.
 - [f.lux](https://justgetflux.com/) - Automatically adjust your computer screen to match lighting. ![Freeware][Freeware Icon]


### PR DESCRIPTION
Adds **Clippy** to the `Productivity` section, placed alphabetically between `ClipMenu` and `CloudClip`.

## About
Clippy is an actively maintained open-source (MIT) macOS clipboard manager with:

- Content-aware previews for URLs, colors, JSON, code, images
- AI transformations (Ollama locally, or OpenAI / Anthropic / Google Gemini BYO-key)
- Built-in screenshot editor with 20+ annotation tools
- File format converter (image / document / audio / video / data)
- Windows 11-style dock preview
- Shelf for drag-and-drop files

Repo: https://github.com/yarasaa/Clippy
License: MIT
Requires: macOS 13+

## Checklist
- [x] Not a duplicate
- [x] One-sentence description
- [x] Alphabetical placement within section
- [x] Open-Source + Freeware icons