### PR TITLE
Add SnapHotkey — direct hotkey-to-app mapping for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@
 - [Rocket](http://matthewpalmer.net/rocket/) - Makes typing emoji faster and easier using Slack-style shortcuts. ![Freeware][Freeware Icon]
 - [SelfControl](https://selfcontrolapp.com/) - Block access to distracting websites. [![Open-Source Software][OSS Icon]](https://github.com/SelfControlApp/selfcontrol/) ![Freeware][Freeware Icon]
 - [Simplenote](https://simplenote.com/) - Simple cross-platform note taking app with cloud-based syncing. ![Freeware][Freeware Icon]
+- [SnapHotkey](https://snaphotkey.com) - Assign a keyboard shortcut directly to each app — press once to switch instantly, no Cmd+Tab cycling. Distinguishes Left vs Right modifier keys for double the shortcut space.
 - [Taskade](https://apps.apple.com/us/app/taskade-manage-anything/id1490048917/) - Real-time organization and task management tool.
 - [TaskPaper](https://www.taskpaper.com/) - Plain text to-do lists.
 - [Telephone](http://www.64characters.com/telephone/) - A SIP softphone. Make phone calls over the Internet or your company’s network. [![Open-Source Software][OSS Icon]](https://github.com/eofster/Telephone) ![Freeware][Freeware Icon]


### PR DESCRIPTION
SnapHotkey maps keyboard shortcuts directly to apps — press one key, switch instantly, no cycling. Distinguishes Left vs Right Command keys. $9.99 one-time. https://snaphotkey.com

Added to the **Productivity** section, alphabetically between Simplenote and Taskade.