### PR TITLE
Add 不拖 (Butuo) — free minimalist to-do app for iPhone & iPad

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@
 - [SelfControl](https://selfcontrolapp.com/) - Block access to distracting websites. [![Open-Source Software][OSS Icon]](https://github.com/SelfControlApp/selfcontrol/) ![Freeware][Freeware Icon]
 - [Simplenote](https://simplenote.com/) - Simple cross-platform note taking app with cloud-based syncing. ![Freeware][Freeware Icon]
 - [Taskade](https://apps.apple.com/us/app/taskade-manage-anything/id1490048917/) - Real-time organization and task management tool.
+- [不拖 (Butuo)](https://apps.apple.com/app/id6761042128) - Minimalist to-do app for iPhone, iPad. No account, no server, no sync. Local storage only. Free. ![Freeware][Freeware Icon]
 - [TaskPaper](https://www.taskpaper.com/) - Plain text to-do lists.
 - [Telephone](http://www.64characters.com/telephone/) - A SIP softphone. Make phone calls over the Internet or your company’s network. [![Open-Source Software][OSS Icon]](https://github.com/eofster/Telephone) ![Freeware][Freeware Icon]
 - [TextExpander](https://smilesoftware.com/textexpander) - Create custom keyboard shortcuts for frequently-used text and pictures.


### PR DESCRIPTION
## What is 不拖 (Butuo)?

A minimalist to-do app for iPhone and iPad that fits perfectly in the Productivity section alongside OmniFocus and Taskade.

### Why it belongs here
- 🍎 Native iOS app (iPhone + iPad)
- **Completely free** — no subscription, no in-app purchases
- **No account, no server, no sync** — all data stored locally on device only
- Zero-friction UI: open the app, write it down, cross it off
- No ads, no tracking

**App Store:** https://apps.apple.com/app/id6761042128