### PR TITLE
Add Awesome Mac mini Home Server to Miscellaneous

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,6 +456,7 @@ Ansible playbook to configure a development and desktop environment from a clean
 * [Power Tools](http://www.slant.co/topics/523/~power-user-tools-for-mac-osx)
 * [Show hidden files](http://ianlunn.co.uk/articles/quickly-showhide-hidden-files-mac-os-x-mavericks/)
 * [Mac Power Users](https://www.relay.fm/mpu)
+* [Awesome Mac mini Home Server](https://github.com/momenbasel/awesome-mac-mini-homeserver) - Curated tools for turning an Apple Silicon Mac mini into a 24/7 agentic AI home server.
 * [Awesome Screensavers](https://github.com/aharris88/awesome-osx-screensavers)
 
 


### PR DESCRIPTION
Adds a link to [Awesome Mac mini Home Server](https://github.com/momenbasel/awesome-mac-mini-homeserver) under the Miscellaneous section.

It's a curated list focused specifically on running an Apple Silicon Mac mini as a 24/7 home server, with agentic AI (Ollama, Claude Code, MLX, WhisperKit), self-hosted apps, media server, and smart home setups. Complementary in scope to awesome-macOS - narrower focus on 24/7 server use.

- 260+ curated entries across 32 categories
- CC0-1.0 licensed
- awesome-lint + lychee link-check CI green
- Covers agentic AI, self-hosted apps, media, smart home, CI/CD on Mac mini, Time Machine server setup, etc.

Thanks for maintaining awesome-macOS.