### PR TITLE
Add TimeNest to Backup

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@
 ### Backup
 - [Arq](https://www.arqbackup.com/) - Encrypted backups to Amazon, Dropbox, Google, OneDrive, etc.
 - [Carbon Copy Cloner](http://bombich.com) - Create incremental and fully bootable backups of your Mac to external storage.
+- [TimeNest](https://github.com/momenbasel/timenest) - Self-hosted network Time Machine server that turns a Mac mini, Raspberry Pi, or any Linux box into a Time Capsule replacement for every Mac on your LAN. Docker stack with Samba + `vfs_fruit`, Avahi for Bonjour, and a FastAPI admin UI. [![Open-Source Software][OSS Icon]](https://github.com/momenbasel/timenest) ![Freeware][Freeware Icon]
 
 ### Chat Clients
 

--- a/README.md
+++ b/README.md
@@ -456,6 +456,7 @@ Ansible playbook to configure a development and desktop environment from a clean
 * [Power Tools](http://www.slant.co/topics/523/~power-user-tools-for-mac-osx)
 * [Show hidden files](http://ianlunn.co.uk/articles/quickly-showhide-hidden-files-mac-os-x-mavericks/)
 * [Mac Power Users](https://www.relay.fm/mpu)
+* [Awesome Mac mini Home Server](https://github.com/momenbasel/awesome-mac-mini-homeserver) - Curated tools for turning an Apple Silicon Mac mini into a 24/7 agentic AI home server.
 * [Awesome Screensavers](https://github.com/aharris88/awesome-osx-screensavers)
 
 


### PR DESCRIPTION
Hi, adding [TimeNest](https://github.com/momenbasel/timenest) under Backup.

TimeNest is a self-hosted, open-source network Time Machine server - a direct replacement for Apple's discontinued Time Capsule. It advertises a share over Bonjour as a \`TimeCapsule8,119\`, so Finder and System Settings on every Mac on the LAN pick it up automatically without typing an IP.

- Runs on Mac mini, Raspberry Pi, or any Linux box via \`docker compose up -d\`
- Per-user SMB shares with Time Machine quotas
- Dark-mode FastAPI admin UI with live sessions and SMART
- MIT, no telemetry

Repo: https://github.com/momenbasel/timenest