### PR TITLE
Add Murmur to Audio section

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@
 - [Audio Profile Manager](https://apps.apple.com/us/app/audio-profile-manager/id1484150558?ls=1&mt=12) - Allows you to pin input/output devices for each particular combination of connected devices. May suppress HDMI displays from being chosen.
 - [BackgroundMusic](https://github.com/kyleneideck/BackgroundMusic) - Record system audio, control audio levels for individual apps, and automatically pauses your music player when other audio starts playing and unpauses it afterwards. [![Open-Source Software][OSS Icon]](https://github.com/kyleneideck/BackgroundMusic) ![Freeware][Freeware Icon]
 - [krisp](https://krisp.ai/) - AI-powered app that removes background noise and echo from meetings leaving only human voice.
+- [Murmur](https://murmurtts.com/) - On-device text-to-speech studio with 860+ voices, voice cloning, and four AI models running entirely on Apple Silicon via MLX.
 - [Plug](https://plugformac.com) - Discover and listen to music from Hype Machine. [![Open-Source Software][OSS Icon]](https://github.com/wulkano/Plug) ![Freeware][Freeware Icon]
 - [Recordia](https://sindresorhus.com/recordia) - Record audio directly from the menu bar or with a global keyboard shortcut.
 - [VOX Player](https://coppertino.com/vox/mac) - Play numerous lossy and lossless audio formats.


### PR DESCRIPTION
<!-- Filled out per .github/PULL_REQUEST_TEMPLATE.md and .github/contributing.md -->

0. [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
1. [x] I confirm that I have read and understood the sections about "AI"-adjacent software
2. **Project URL:** https://murmurtts.com/
3. **Why should this project be added:** Murmur is a native macOS text-to-speech studio that runs entirely on the user's Mac via Apple's MLX framework. It bundles four specialised TTS models (Kokoro, Qwen3-TTS, Fish S2 Pro, Chatterbox) for local speech synthesis with 860+ voices across 25+ languages, plus voice cloning from a 10-second sample. The Audio section currently has no TTS app, and Murmur fills that gap with a local-first, no-cloud, no-subscription option used by podcasters, audiobook authors, and YouTubers.
4. [x] End all descriptions with a full stop/period
5. [x] Entry is ordered alphabetically (placed between `krisp` and `Plug` per the existing case-insensitive ordering)
6. [x] Appropriate icon(s) added if applicable (OSS, freeware) — N/A, Murmur is commercial paid software ($49 one-time)

## Re: AI-adjacent software policy

Per `contributing.md`: "Leveraging local, specialised ML models as part of a larger process is fine." Murmur is not an LLM wrapper, chatbot, or agent. It is a desktop audio production tool that uses bundled, specialised TTS models locally on Apple Silicon, analogous to the "manual image editing suite featuring a smart repair brush" example given in the guidelines.

## Re: commercial app evaluation

Murmur does not offer a free trial. Per the guidelines, I'm happy to provide **2 perpetual licenses** for the maintainer team to evaluate. Please share an email address (here or to tarunyadav9761@gmail.com) and I'll send both license keys via Gumroad immediately.

## Tech notes

- macOS 14+, Apple Silicon required (M1 or later)
- Native Swift app, no Electron
- No tracking parameters in the URL
- Currently shipping v1.0.6