### PR TITLE
Add Vibes to Audio

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@
 - [krisp](https://krisp.ai/) - AI-powered app that removes background noise and echo from meetings leaving only human voice.
 - [Plug](https://plugformac.com) - Discover and listen to music from Hype Machine. [![Open-Source Software][OSS Icon]](https://github.com/wulkano/Plug) ![Freeware][Freeware Icon]
 - [Recordia](https://sindresorhus.com/recordia) - Record audio directly from the menu bar or with a global keyboard shortcut.
+- [Vibes](https://vibesdj.io/) - DJ library organizer that sorts tracks by mood, energy, and technique, then exports prepped crates to Rekordbox, Serato DJ, Engine DJ, and Lexicon DJ.
 - [VOX Player](https://coppertino.com/vox/mac) - Play numerous lossy and lossless audio formats.
 - [XLD](http://tmkk.undo.jp/xld/index_e.html) - Rip/Decode/convert/play various "lossless" audio files. [![Open-Source Software][OSS Icon]](https://code.google.com/archive/p/xld/source) ![Freeware][Freeware Icon]
 


### PR DESCRIPTION
Adds Vibes — a native macOS DJ library organizer — to the Audio section.

- Website: https://vibesdj.io/
- Platform: macOS 11+ (Apple Silicon, native Tauri v2 app)
- License: Commercial (paid)

Vibes sorts DJ tracks by mood, energy, and technique, then exports prepped crates to Rekordbog, Serato DJ, Engine DJ, and Lexicon DJ. Fits alongside existing commercial audio apps in the section (Audio Hijack, krisp, VOX Player).