### PR TITLE
Add Bzz - keyboard layout switcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@
 - [BetterZip](https://macitbetter.com/) - A very capable and full-featured archive manager.
 - [BitBar](https://github.com/matryer/bitbar) - Display output of any script to the menu bar. [![Open-Source Software][OSS Icon]](https://github.com/matryer/bitbar) ![Freeware][Freeware Icon]
 - [Burn](http://burn-osx.sourceforge.net/Pages/English/home.html) - No-nonsense burning of Data/Audio/Video CDs and DVDs, including copying. [![Open-Source Software][OSS Icon]](https://sourceforge.net/p/burn-osx/code-git/ci/master/tree/) ![Freeware][Freeware Icon]
+- [Bzz](https://github.com/zlopixatel/bzz) - Open-source automatic keyboard layout switcher. Mistyping "ghbdtn" instead of "привет"? Bzz instantly fixes it. [![Open-Source Software][OSS Icon]](https://github.com/zlopixatel/bzz) ![Freeware][Freeware Icon]
 - [CheatSheet](https://www.cheatsheetapp.com/CheatSheet/) - Know your short cuts. ![Freeware][Freeware Icon]
 - [ClipboardCleaner](https://github.com/Zuehlke/Clipboard_Cleaner) - Automatically removes text formatting from the clipboard. [![Open-Source Software][OSS Icon]](https://github.com/Zuehlke/Clipboard_Cleaner) ![Freeware][Freeware Icon]
 - [CommandQ](https://clickontyler.com/commandq/) - Never accidentally quit an app again.


### PR DESCRIPTION
Adds [Bzz](https://github.com/zlopixatel/bzz) — an open-source automatic keyboard layout switcher for macOS. Detects mistyped words like `ghbdtn` (typed in QWERTY when meaning Russian) and fixes them on the fly to `привет`.

- MIT licensed, written in Go
- Active CGEventTap intercepts Enter before submit (works in Slack/Telegram/Notion)
- Fuzzy matching catches typos
- Cmd+Z undo with per-app learning

Inserted alphabetically in the Utilities section between Burn and CheatSheet.