### PR TITLE
Add WobblePic to Graphics

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@
 - [Pixelmator](http://www.pixelmator.com/mac/) - Powerful image editor, possible Photoshop alternative.
 - [Sketch](http://www.sketchapp.com/) - Hybrid vector/bitmap layout application, especially useful for UI, web and mobile design.
 - [Sketch Toolbox](http://sketchtoolbox.com/) - A super simple plugin manager for Sketch. [![Open-Source Software][OSS Icon]](https://github.com/buzzfeed/Sketch-Toolbox)
+- [WobblePic](https://wobblepic.com) - An image viewer with soft-body physics that lets you wobble photos like rubber. ![Freeware][Freeware Icon]
 - [xScope](http://xscopeapp.com/) - Tools for measuring, inspecting and testing on-screen graphics and layouts.
 
 


### PR DESCRIPTION
<!-- Thanks for contributing to awesome-macOS  -->

<!-- Please fill out the following: -->

0. [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
1. [x] I confirm that I have read and understood the sections about "AI"-adjacent software
2. [x] Project URL: https://wobblepic.com
3. [x] Why should this project be added:

WobblePic is a native macOS image viewer (also runs on Windows) whose primary feature is **real-time soft-body physics simulation** — drag any part of a photo and it stretches and bounces like rubber, driven by a mass-spring system rendered on the GPU at 60fps. The wobble interaction is the core product and is fully self-contained.

It also offers **optional** SAM2-based object segmentation (running locally via CoreML on Apple Silicon / Neural Engine) so a user can isolate one subject before wobbling it. This matches the contribution guideline's allowed pattern: "Leveraging local, specialised ML models as part of a larger process is fine. Think... a manual image editing suite featuring a smart repair brush." WobblePic is the manual-editing equivalent — wobble is the manual interaction, segmentation is a smart helper that can be turned off.

Other relevant facts:
- Native app, **not Electron** (Python + OpenGL).
- Closed-source freeware, free for personal and commercial use.
- Actively maintained (v1.3.7, macOS Sequoia+ supported).
- Website: https://wobblepic.com.
- Source / releases: https://github.com/wobblepic/WobblePicPublic.

4. [x] End all descriptions with a full stop/period
5. [x] Entry is ordered alphabetically (placed in Graphics section between "Sketch Toolbox" and "xScope")
6. [x] Appropriate icon(s) added if applicable (Freeware badge included; no OSS badge as the app is closed-source)
