### PR TITLE
Add Whisky (Wine wrapper for macOS) to Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,7 @@
 - [Ukelele](http://scripts.sil.org/cms/scripts/page.php?site_id=nrsi&id=ukelele) - Unicode Keyboard Layout Editor. ![Freeware][Freeware Icon]
 - [Übersicht](http://tracesof.net/uebersicht/) - Run system commands and display their output on your desktop as widgets. [![Open-Source Software][OSS Icon]](https://github.com/felixhageloh/uebersicht) ![Freeware][Freeware Icon]
 - [The Unarchiver](https://theunarchiver.com/) - Unarchive many different kinds of archive files. ![Freeware][Freeware Icon]
+- [Whisky](https://github.com/frankea/Whisky) - Native SwiftUI Wine wrapper for macOS with D3DMetal/DXVK backends and built-in launcher compatibility (Steam, Epic, EA App, Battle.net). Active community fork of the archived whisky-app/whisky. [![Open-Source Software][OSS Icon]](https://github.com/frankea/Whisky) ![Freeware][Freeware Icon]
 - [Wineskin](https://github.com/Gcenx/WineskinServer) - Run Windows applications and games on your Mac. [![Open-Source Software][OSS Icon]](https://github.com/Gcenx/WineskinServer) ![Freeware][Freeware Icon]
 
 ### Video


### PR DESCRIPTION
Adds [Whisky](https://github.com/frankea/Whisky) to the Utilities section, alphabetically just before Wineskin (the other Wine wrapper currently listed).

## What it is

Whisky is a native SwiftUI Wine wrapper for macOS, supporting D3DMetal and DXVK graphics backends with built-in launcher compatibility (Steam, Epic, EA App, Battle.net). Signed/notarized for Apple Silicon, Sparkle-delivered updates.

## Why this PR is appropriate for the list

- ✅ Open source (GPL v3) — repo includes source, releases, and docs
- ✅ macOS native (built with SwiftUI for Sequoia 15+)
- ✅ Distinct from Wineskin (different architecture, modern Wine 11 + macOS-native UI)
- ✅ Actively maintained — latest release `app-v3.0.1` shipped May 2026

## Note on the upstream fork relationship

The original `whisky-app/whisky` repo was [archived in April 2025](https://github.com/whisky-app/whisky). The fork at `frankea/Whisky` continued development through 2026, addressing the backlog of upstream issues and adding new functionality. Maintains a per-issue [audit](https://github.com/frankea/Whisky/blob/main/docs/AUDIT.md) of how it addresses upstream concerns.

Single-line README addition.