### PR TITLE
Add Skilly to Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@
 - [Rocket](http://matthewpalmer.net/rocket/) - Makes typing emoji faster and easier using Slack-style shortcuts. ![Freeware][Freeware Icon]
 - [SelfControl](https://selfcontrolapp.com/) - Block access to distracting websites. [![Open-Source Software][OSS Icon]](https://github.com/SelfControlApp/selfcontrol/) ![Freeware][Freeware Icon]
 - [Simplenote](https://simplenote.com/) - Simple cross-platform note taking app with cloud-based syncing. ![Freeware][Freeware Icon]
+- [Skilly](https://tryskilly.app) - Voice-first AI tutor that watches your Mac screen and walks you through any app (Blender, Figma, Xcode, Photoshop) in real time. Native Swift + ScreenCaptureKit + OpenAI Realtime, 20+ languages. [![Open-Source Software][OSS Icon]](https://github.com/tryskilly/skilly)
 - [Taskade](https://apps.apple.com/us/app/taskade-manage-anything/id1490048917/) - Real-time organization and task management tool.
 - [TaskPaper](https://www.taskpaper.com/) - Plain text to-do lists.
 - [Telephone](http://www.64characters.com/telephone/) - A SIP softphone. Make phone calls over the Internet or your company’s network. [![Open-Source Software][OSS Icon]](https://github.com/eofster/Telephone) ![Freeware][Freeware Icon]


### PR DESCRIPTION
Adds [Skilly](https://tryskilly.app) under **Productivity**.

A voice-first AI tutor for Mac that watches your screen and walks you through any app (Blender, Figma, Xcode, Photoshop, etc.) out loud. Press a hotkey, ask a question, and it screenshots your active app, narrates the answer, and points your cursor at the exact UI element.

**Stack:** native Swift, ScreenCaptureKit, NSPanel-on-every-space, OpenAI Realtime API. macOS 14.2+. No Electron.

**Open source under Apache-2.0:** [github.com/tryskilly/skilly](https://github.com/tryskilly/skilly). Ships with 5 free standalone skill curricula in markdown.

Inserted alphabetically between Simplenote and Taskade. Followed the existing entry format with the OSS badge.

Disclosure: I'm the author. Happy to adjust the description if anything doesn't fit your editorial style.