### PR TITLE
Add OpenQuack

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@
 - [MenubarX](https://MenubarX.app) - A powerful menu bar browser.
 - [OmniFocus](https://www.omnigroup.com/omnifocus) - An incredible task management platform for Mac, iPad, and iPhone.
 - [OmniOutliner](https://www.omnigroup.com/omnioutliner/) - Perfect for collecting information, outlining ideas, adding structure to any sort of writing, and much more.
+- [OpenQuack](https://github.com/larryxiao/openquack) - Local-only voice dictation for macOS. Press a hotkey, speak, transcript is pasted at cursor. WhisperKit on Apple Silicon, 99 languages, no telemetry, no account. [![Open-Source Software][OSS Icon]](https://github.com/larryxiao/openquack) ![Freeware][Freeware Icon]
 - [Pandan](https://apps.apple.com/app/id1569600264) - Time awareness in your menu bar. ![Freeware][Freeware Icon]
 - [Paste](http://pasteapp.me) - The new way to copy & paste for Mac.
 - [PDF Archiver](https://github.com/JulianKahnert/PDF-Archiver) - A nice tool for tagging and archiving tasks. [![Open-Source Software][OSS Icon]](https://github.com/JulianKahnert/PDF-Archiver)


### PR DESCRIPTION
0. [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
1. [x] I confirm that I have read and understood the sections about "AI"-adjacent software
2. [x] Project URL: https://github.com/larryxiao/openquack
3. [x] Why should this project be added: OpenQuack is a privacy-first local voice dictation menu bar app for macOS — push a hotkey, speak, the transcript is pasted at the cursor. It runs WhisperKit on Apple Silicon, supports 99 Whisper languages, and never sends audio or text off the device. MIT-licensed, no signup, no telemetry. It's a specialised-ML-as-part-of-a-larger-process app (per the contribution rules), not an LLM/agent wrapper — Whisper is the model, the rest is a Mac menu-bar app around it. Inserted alphabetically in the Audio section between Murmur and Plug.
4. [x] End all descriptions with a full stop/period
5. [x] Entry is ordered alphabetically
6. [x] Appropriate icon(s) added if applicable (OSS, freeware)