### PR TITLE
Add TablePro

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@
 - [SourceTree](https://www.sourcetreeapp.com/) - A free Git & Mercurial client. ![Freeware][Freeware Icon]
 - [Swiftify](https://objectivec2swift.com/#/xcode-extension/) - Objective-C to Swift code converter and Xcode & Finder extensions.
 - [TablePlus](https://tableplus.com/) - A modern, native GUI for multiple databases.
+- [TablePro](https://tablepro.app) - A native database client for MySQL, PostgreSQL, SQLite, MongoDB, Redis, and more. [![Open-Source Software][OSS Icon]](https://github.com/TableProApp/TablePro) ![Freeware][Freeware Icon]
 - [Touch Bar Simulator](https://github.com/sindresorhus/touch-bar-simulator) - The macOS Touch Bar Simulator as a standalone app. [![Open-Source Software][OSS Icon]](https://github.com/sindresorhus/touch-bar-simulator) ![Freeware][Freeware Icon]
 - [Tower](https://www.git-tower.com/) - The most powerful Git client.
 - [Trailer](https://ptsochantaris.github.io/trailer/) - Configurable menubar Git notifications with accompanying native iOS app. [![Open-Source Software][OSS Icon]](https://github.com/ptsochantaris/trailer)


### PR DESCRIPTION
0. [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
1. [x] I confirm that I have read and understood the sections about "AI"-adjacent software
2. [x] Project URL: https://tablepro.app (source: https://github.com/TableProApp/TablePro)
3. [x] Why should this project be added: TablePro is a native macOS database client built with SwiftUI and AppKit, AGPL-3.0 licensed. It connects to MySQL, PostgreSQL, SQLite, MongoDB, Redis, and 15+ more databases using native drivers (no Electron, no JDBC). Free and open source. Disclosure: I am the author.
4. [x] End all descriptions with a full stop/period
5. [x] Entry is ordered alphabetically (placed after TablePlus in the Developers section)
6. [x] Appropriate icon(s) added if applicable (OSS, freeware)