### PR TITLE
Add Mundwerk

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@
 - [LaunchBar](https://www.obdev.at/products/launchbar/index.html) - Start applications, navigate folders, manipulate files, control your Mac and much more just by using the keyboard.
 - [MeetingBar](https://meetingbar.onrender.com) - Your meetings in MacOS status bar [![Open-Source Software][OSS Icon]](https://github.com/leits/MeetingBar) ![Freeware][Freeware Icon]
 - [MenubarX](https://MenubarX.app) - A powerful menu bar browser.
+- [Mundwerk](https://mundwerkapp.de) - Push-to-talk dictation menu bar app with German-English code-switching, runs whisper.cpp locally.
 - [OmniFocus](https://www.omnigroup.com/omnifocus) - An incredible task management platform for Mac, iPad, and iPhone.
 - [OmniOutliner](https://www.omnigroup.com/omnioutliner/) - Perfect for collecting information, outlining ideas, adding structure to any sort of writing, and much more.
 - [Pandan](https://apps.apple.com/app/id1569600264) - Time awareness in your menu bar. ![Freeware][Freeware Icon]


### PR DESCRIPTION
0. [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
1. [x] I confirm that I have read and understood the sections about "AI"-adjacent software
2. Project URL: https://mundwerkapp.de
3. Why should this project be added: Mundwerk is a native macOS menu bar dictation app that runs whisper.cpp locally on Apple Silicon. Fits the rule "Leveraging local, specialised ML models as part of a larger process is fine" — Whisper is the local STT backend, not an LLM/chatbot wrapper. Native Swift (no Electron). Commercial with a 7-day free trial without account.
4. [x] End all descriptions with a full stop/period
5. [x] Entry is ordered alphabetically (placed between MenubarX and OmniFocus in Productivity)
6. [x] Appropriate icon(s) added if applicable — none needed (commercial, no OSS, no freeware)