### PR TITLE
Add LogGate Pro to Video section

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,6 +336,7 @@
 
 - [HandBrake](https://handbrake.fr/) - High performance video encoding and conversion tools with a nice GUI. [![Open-Source Software][OSS Icon]](https://github.com/HandBrake/HandBrake)
 - [IINA](https://lhc70000.github.io/iina/) - Media player with a minimalist design. [![Open-Source Software][OSS Icon]](https://github.com/lhc70000/iina) ![Freeware][Freeware Icon]
+- [LogGate Pro](https://loggate.tech/) - Apple Log video converter for iPhone 15 Pro and later — converts Log footage to H.264/H.265 with built-in LUT grading.
 - [mpv](https://mpv.io/) - Media player. [![Open-Source Software][OSS Icon]](https://github.com/mpv-player/mpv)
 - [ScreenFlow](http://www.telestream.net/screenflow/) - Screencasting and video editing software.
 - [Subler](https://bitbucket.org/galad87/subler/wiki/Home) - Mux and tag MP4 files. [![Open-Source Software][OSS Icon]](https://bitbucket.org/galad87/subler/wiki/Home) ![Freeware][Freeware Icon]


### PR DESCRIPTION
## What is LogGate Pro?

[LogGate Pro](https://loggate.tech/) is a macOS app that converts Apple Log video footage from iPhone 15 Pro and later models to standard H.264 or H.265, with built-in LUT grading options.

iPhone 15 Pro and newer can shoot in Apple Log for professional color grading, but standard players can't display it correctly. LogGate Pro provides a fast, lightweight solution to convert and grade this footage without a full NLE.

- **App Store:** https://apps.apple.com/app/id6761159398
- **Website:** https://loggate.tech/

## Placement

Added under **Video**, after IINA (alphabetical order: L comes after I).

## Checklist

- [x] macOS native app
- [x] Available on the Mac App Store
- [x] Fits the Video category
- [x] Entry follows existing format