### PR TITLE
Add muxbar — menu bar tmux controller for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@
 - [Kaleidoscope](http://www.kaleidoscopeapp.com/) - Powerful diff and merge application supporting text, images, and folders.
 - [Knuff](https://github.com/KnuffApp/Knuff) - The debug application for Apple Push Notification Service (APNs). [![Open-Source Software][OSS Icon]](https://github.com/KnuffApp/Knuff) ![Freeware][Freeware Icon]
 - [Medis](https://getmedis.com) - A modern GUI for Redis.
+- [muxbar](https://github.com/1989v/muxbar) - Menu bar app for tmux session management on macOS — list / attach / kill / live preview, plus a closed-lid mode for in-bag work. [![Open-Source Software][OSS Icon]](https://github.com/1989v/muxbar) ![Freeware][Freeware Icon]
 - [Pasteboard Viewer](https://apps.apple.com/app/id1499215709) - Inspect the system pasteboards. [![Open-Source Software][OSS Icon]](https://github.com/sindresorhus/Pasteboard-Viewer) ![Freeware][Freeware Icon]
 - [Paw](https://luckymarmot.com/paw) - The ultimate REST client.
 - [pgMagic](https://pgmagic.app) - A PostgreSQL client that lets you talk to your database in SQL or natural language.


### PR DESCRIPTION
Adds [muxbar](https://github.com/1989v/muxbar) — a native macOS menu bar app for tmux session management.

- List / attach / kill tmux sessions from the menu bar with live preview
- Closed-lid mode keeps system awake with the laptop closed (no external display required)
- YAML templates for session layouts
- MIT licensed, Swift/SwiftUI, macOS 13+

Inserted alphabetically under the **Developers** section (between Medis and Pasteboard Viewer).