### PR TITLE
Add Parakey to Audio

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@
 - [BackgroundMusic](https://github.com/kyleneideck/BackgroundMusic) - Record system audio, control audio levels for individual apps, and automatically pauses your music player when other audio starts playing and unpauses it afterwards. [![Open-Source Software][OSS Icon]](https://github.com/kyleneideck/BackgroundMusic) ![Freeware][Freeware Icon]
 - [krisp](https://krisp.ai/) - AI-powered app that removes background noise and echo from meetings leaving only human voice.
 - [Murmur](https://murmurtts.com/) - On-device text-to-speech studio with 860+ voices, voice cloning, and four AI models running entirely on Apple Silicon via MLX.
-- [Parakey](https://github.com/rcourtman/parakey) - Push-to-talk dictation menu bar app with on-device speech-to-text running on Apple Silicon via Parakeet-MLX. [![Open-Source Software][OSS Icon]](https://github.com/rcourtman/parakey) ![Freeware][Freeware Icon]
+- [Parakey](https://github.com/rcourtman/parakey) - Push-to-talk dictation that runs Parakeet TDT v3 on the Apple Neural Engine via CoreML — ~100 ms key-to-paste, 2.2 MB native Swift binary. [![Open-Source Software][OSS Icon]](https://github.com/rcourtman/parakey) ![Freeware][Freeware Icon]
 - [Plug](https://plugformac.com) - Discover and listen to music from Hype Machine. [![Open-Source Software][OSS Icon]](https://github.com/wulkano/Plug) ![Freeware][Freeware Icon]
 - [Recordia](https://sindresorhus.com/recordia) - Record audio directly from the menu bar or with a global keyboard shortcut.
 - [VOX Player](https://coppertino.com/vox/mac) - Play numerous lossy and lossless audio formats.

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@
 - [BackgroundMusic](https://github.com/kyleneideck/BackgroundMusic) - Record system audio, control audio levels for individual apps, and automatically pauses your music player when other audio starts playing and unpauses it afterwards. [![Open-Source Software][OSS Icon]](https://github.com/kyleneideck/BackgroundMusic) ![Freeware][Freeware Icon]
 - [krisp](https://krisp.ai/) - AI-powered app that removes background noise and echo from meetings leaving only human voice.
 - [Murmur](https://murmurtts.com/) - On-device text-to-speech studio with 860+ voices, voice cloning, and four AI models running entirely on Apple Silicon via MLX.
+- [Parakey](https://github.com/rcourtman/parakey) - Push-to-talk dictation menu bar app with on-device speech-to-text running on Apple Silicon via Parakeet-MLX. [![Open-Source Software][OSS Icon]](https://github.com/rcourtman/parakey) ![Freeware][Freeware Icon]
 - [Plug](https://plugformac.com) - Discover and listen to music from Hype Machine. [![Open-Source Software][OSS Icon]](https://github.com/wulkano/Plug) ![Freeware][Freeware Icon]
 - [Recordia](https://sindresorhus.com/recordia) - Record audio directly from the menu bar or with a global keyboard shortcut.
 - [VOX Player](https://coppertino.com/vox/mac) - Play numerous lossy and lossless audio formats.


### PR DESCRIPTION
Adds [Parakey](https://github.com/rcourtman/parakey) to the **Audio** section, alphabetically between Murmur and Plug.

Parakey is a push-to-talk dictation menu bar app for Apple Silicon Macs. It runs the Parakeet TDT v3 speech model on the **Apple Neural Engine** via **CoreML** (rather than on the GPU), targeting ~100 ms key-release-to-paste latency. The release zip is 2.2 MB; runtime memory sits around 80 MB with 0% CPU between dictations.

It's a complementary entry to Murmur (already in this section): Murmur is on-device TTS on Apple Silicon, Parakey is on-device STT on Apple Silicon.

- Repo: https://github.com/rcourtman/parakey
- Install: `brew install --cask rcourtman/parakey/parakey`
- Native Swift, open source (MIT), no telemetry, Apple Silicon only

Description format follows existing entries (sentence + OSS + Freeware icons).