### PR TITLE
Add Brewfile to Setup section

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,6 +385,12 @@
 
 ## Setup
 
+### Brewfile
+
+Idempotent one-command MacBook setup (Homebrew, Oh My Zsh, AWS, kubectl, macOS defaults). Skips apps already installed manually via `.app`/`pkgutil` detection.
+
+* https://github.com/marchenkovit/Brewfile
+
 ### DevMyMac
 
 * https://github.com/adamisntdead/DevMyMac


### PR DESCRIPTION
## What

Adds [marchenkovit/Brewfile](https://github.com/marchenkovit/Brewfile) to the **Setup** section.

## Why

It's a one-command idempotent MacBook setup script — alongside `laptop`, `mac-dev-setup`, `DevMyMac`. Bundles Homebrew packages, Oh My Zsh, AWS/git/VS Code/Claude Code configs, macOS defaults, and EKS kubectl context auto-configuration.

**Distinguishing feature:** `install.sh` checks `/Applications/<app>.app` and `pkgutil --pkgs` for each cask before installing, so it's safe to re-run on a machine where the user has installed apps manually (no overwrites, no duplicate downloads).

## Checklist

- [x] Alphabetical placement in the section (B before D)
- [x] One-line description added
- [x] URL points to a public repository with active development
- [x] Includes MIT LICENSE, CI workflow, CONTRIBUTING, Code of Conduct, releases
- [x] Has a hosted docs site at https://marchenkovit.github.io/Brewfile/