### PR TITLE
Add Icon Composer to Developers

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@
 - [Hopper Dissassembler](https://www.hopperapp.com) - A Dissassembler for MacOS and Linux. Has a Demo option for 30 minutes of productivity.
 - [Hosts](https://github.com/specialunderwear/Hosts.prefpane) - Edit hosts file. [![Open-Source Software][OSS Icon]](https://github.com/specialunderwear/Hosts.prefpane) ![Freeware][Freeware Icon]
 - [Iconology](https://github.com/liamrosenfeld/Iconology) - Edit Icons and then Export to Xcode, Icns, Ico, Favicon, Mac Iconset, or a Custom List of Sizes. [![Open-Source Software][OSS Icon]](https://github.com/liamrosenfeld/Iconology) ![Freeware][Freeware Icon]
+- [Icon Composer](https://developer.apple.com/icon-composer/) - Official Apple tool for composing and previewing app icons across platforms.
 - [ImageAlpha](https://pngmini.com/) - Apply lossy compression on PNG files with or without transparency for more efficient files. [![Open-Source Software][OSS Icon]](https://github.com/pornel/ImageAlpha) ![Freeware][Freeware Icon]
 - [ImageOptim](https://imageoptim.com/mac) - Makes images take up less disk space and load faster. [![Open-Source Software][OSS Icon]](https://github.com/ImageOptim/ImageOptim) ![Freeware][Freeware Icon]
 - [Integrity](http://peacockmedia.software/mac/integrity/free.html) - Easily find your website's broken links. ![Freeware][Freeware Icon]


### PR DESCRIPTION
<!-- Thanks for contributing to awesome-macOS  -->

<!-- Please fill out the following: -->

0. [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
1. [x] I confirm that I have read and understood the sections about "AI"-adjacent software
2. [x] Project URL: [https://developer.apple.com/icon-composer/](https://developer.apple.com/icon-composer/)
3. [x] Why should this project be added: Official Apple tool for composing and previewing app icons across Apple platforms, useful for macOS/iOS developers managing icon variants.
4. [x] End all descriptions with a full stop/period
5. [x] Entry is ordered alphabetically
6. [x] Appropriate icon(s) added if applicable (OSS, freeware)

<!--

Again, please read https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md if you didn't yet.
If you don't fill out this template or replace it wholesale, your pull request will be closed without discussion.

-->