### PR TITLE
Add NotchIA to Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@
 - [LaunchBar](https://www.obdev.at/products/launchbar/index.html) - Start applications, navigate folders, manipulate files, control your Mac and much more just by using the keyboard.
 - [MeetingBar](https://meetingbar.onrender.com) - Your meetings in MacOS status bar [![Open-Source Software][OSS Icon]](https://github.com/leits/MeetingBar) ![Freeware][Freeware Icon]
 - [MenubarX](https://MenubarX.app) - A powerful menu bar browser.
+- [NotchIA](https://notchia.app/) - Turns the MacBook notch into an interactive cockpit with music, calendar, Pomodoro Focus, on-device Apple Intelligence RSS digest, and live Claude Code/Codex/Copilot status. Open-core fork of Boring Notch.
 - [OmniFocus](https://www.omnigroup.com/omnifocus) - An incredible task management platform for Mac, iPad, and iPhone.
 - [OmniOutliner](https://www.omnigroup.com/omnioutliner/) - Perfect for collecting information, outlining ideas, adding structure to any sort of writing, and much more.
 - [Pandan](https://apps.apple.com/app/id1569600264) - Time awareness in your menu bar. ![Freeware][Freeware Icon]


### PR DESCRIPTION
Adds NotchIA to the Productivity section.

NotchIA is a macOS 15+ app that turns the MacBook notch into an interactive cockpit:

- Multi-source media (Apple Music, Spotify, YouTube Music) with synced lyrics
- Calendar (iCal + Reminders) and full Pomodoro Focus
- On-device Apple Intelligence RSS Digest (Foundation Models, macOS 26+, graceful fallback on 15)
- Live AI status for Claude Code, ChatGPT Codex, and GitHub Copilot — 10 states, token stats, 5h/7d quotas
- 16-format file converter, unlimited clipboard history, system HUD replacement
- i18n: French, English, Spanish, German

Site: https://notchia.app/
License: Open-core (base derived from MIT Boring Notch, Pro modules proprietary)
Pricing: Essential tier free for life, Pro €3.99/mo or €39.99 lifetime one-time
Privacy: no telemetry, no third-party AI calls, on-device summaries via Apple Intelligence

Inserted alphabetically between MenubarX and OmniFocus.