### PR TITLE
Add Spokio

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@
 - [Murmur](https://murmurtts.com/) - On-device text-to-speech studio with 860+ voices, voice cloning, and four AI models running entirely on Apple Silicon via MLX.
 - [Plug](https://plugformac.com) - Discover and listen to music from Hype Machine. [![Open-Source Software][OSS Icon]](https://github.com/wulkano/Plug) ![Freeware][Freeware Icon]
 - [Recordia](https://sindresorhus.com/recordia) - Record audio directly from the menu bar or with a global keyboard shortcut.
+- [Spokio](https://spokio.pro/) - Offline text-to-speech app with local voice cloning, batch export, and no cloud uploads.
 - [VOX Player](https://coppertino.com/vox/mac) - Play numerous lossy and lossless audio formats.
 - [XLD](http://tmkk.undo.jp/xld/index_e.html) - Rip/Decode/convert/play various "lossless" audio files. [![Open-Source Software][OSS Icon]](https://code.google.com/archive/p/xld/source) ![Freeware][Freeware Icon]
 


### PR DESCRIPTION
## What

Adds Spokio to the Audio applications section.

## Why

Spokio is a macOS offline text-to-speech app that runs locally, supports voice cloning and batch export, and avoids cloud uploads.