### PR TITLE
Add AI Memory Reader to Developers section

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@
 
 ### Developers
 
+- [AI Memory Reader](https://github.com/nvwalj/ai-memory-reader) - Native macOS reader/editor for AI agent memory files (CLAUDE.md, AGENTS.md, etc.) with GitHub-style markdown, live file watching, JSONL session viewer, and edit mode. [![Open-Source Software][OSS Icon]](https://github.com/nvwalj/ai-memory-reader) ![Freeware][Freeware Icon]
 - [Anvil](http://anvilformac.com/) - Serve up static sites and Rack apps with simple URLs and zero configuration. ![Freeware][Freeware Icon]
 - [Base 2](http://menial.co.uk/base/) - A GUI for managing SQLite databases.
 - [CocoaRestClient](https://mmattozzi.github.io/cocoa-rest-client) - An app for testing REST endpoints. [![Open-Source Software][OSS Icon]](https://github.com/mmattozzi/cocoa-rest-client) ![Freeware][Freeware Icon]


### PR DESCRIPTION
Adds [AI Memory Reader](https://github.com/nvwalj/ai-memory-reader) to the Developers section.

AI Memory Reader is a native macOS app for browsing and editing AI agent memory files — the `CLAUDE.md`, `AGENTS.md`, and per-day memory files that Claude Code, Codex, Cursor, Gemini, GitHub Copilot, Aider, and others write to your home directory. It auto-discovers each agent's memory directory, renders markdown in GitHub style, watches files for live updates, has a JSONL viewer for `~/.claude/projects/*.jsonl` session telemetry (chunked rendering for multi-MB transcripts), and offers an edit mode with ⌘E.

- Native Swift + SwiftUI, ~3 MB universal binary
- Open source (GPL-3.0), free
- Zero network calls — all reads are local