### PR TITLE
Add Clipport

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@
 
 ### Terminal
 
+- [Clipport](https://github.com/arihantsethia/clipport) - Paste local clipboard text and images into remote iTerm sessions. [![Open-Source Software][OSS Icon]](https://github.com/arihantsethia/clipport)
 - [iTerm 2](https://www.iterm2.com/) - A terminal emulator. [![Open-Source Software][OSS Icon]](https://github.com/gnachman/iTerm2) ![Freeware][Freeware Icon]
 
 


### PR DESCRIPTION
Adds Clipport to the Terminal section. Clipport is an open-source macOS/iTerm tool for pasting local clipboard text and images into remote iTerm sessions.