### PR TITLE
Add Ano to Chat Clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@
 - [ChitChat](https://github.com/stonesam92/ChitChat) - A native Mac app wrapper for WhatsApp Web. [![Open-Source Software][OSS Icon]](https://github.com/stonesam92/ChitChat) ![Freeware][Freeware Icon]
 - [Telegram](https://itunes.apple.com/us/app/telegram/id747648890?mt=12) - A messaging app with a focus on speed and security, it’s super fast, simple and free. [![Open-Source Software][OSS Icon]](https://github.com/overtake/TelegramSwift) ![Freeware][Freeware Icon]
 - [Textual](https://www.codeux.com/textual/) - An Internet Relay Chat (IRC) client. [![Open-Source Software][OSS Icon]](https://github.com/Codeux-Software/Textual)
+- [Ano](https://ano.chat/) - High-performance developer chat and workspace with a native in-app terminal and integrated AI.
 
 ### Data Recovery
 


### PR DESCRIPTION
Added [Ano](https://ano.chat/) under Chat Clients. Ano is a collaborative developer workspace combining chat, a native mac/terminal interface, and AI integrations.