### PR TITLE
Add Clipport to Terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@
 
 ### Terminal
 
+- [Clipport](https://github.com/arihantsethia/clipport) - Paste Mac clipboard text and screenshots into remote iTerm SSH sessions. [![Open-Source Software][OSS Icon]](https://github.com/arihantsethia/clipport) ![Freeware][Freeware Icon]
 - [iTerm 2](https://www.iterm2.com/) - A terminal emulator. [![Open-Source Software][OSS Icon]](https://github.com/gnachman/iTerm2) ![Freeware][Freeware Icon]
 
 


### PR DESCRIPTION
0. [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
1. [x] I confirm that I have read and understood the sections about "AI"-adjacent software
2. [x] Project URL: https://github.com/arihantsethia/clipport
3. [x] Why should this project be added: Clipport is a small macOS/iTerm utility for SSH workflows. It lets users paste Mac clipboard text normally and paste screenshots into remote SSH sessions as /tmp/clipport/... file paths, avoiding manual save/scp/paste steps.
4. [x] End all descriptions with a full stop/period
5. [x] Entry is ordered alphabetically
6. [x] Appropriate icon(s) added if applicable (OSS, freeware)

This is a replacement for #819. I closed out the previous attempt and resubmitted with the repository template filled in.

Clipport is not an AI prompt wrapper or LLM interface. It is a terminal/SSH clipboard utility; it can be useful with many terminal workflows, but its main purpose is clipboard-to-remote-session paste behavior.
