### PR TITLE
Add PureSnitch

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,6 +447,7 @@ Ansible playbook to configure a development and desktop environment from a clean
 * [OS-X-Security-and-Privacy-Guide](https://github.com/drduh/OS-X-Security-and-Privacy-Guide) [![Open-Source Software][OSS Icon]](https://github.com/drduh/OS-X-Security-and-Privacy-Guide)
 * [OSXCollector](https://github.com/Yelp/osxcollector) - Forensic evidence collection & analysis toolkit. [![Open-Source Software][OSS Icon]](https://github.com/Yelp/osxcollector) ![Freeware][Freeware Icon]
 * [Pareto Security](https://paretosecurity.app/) - A MenuBar app to automatically audit your Mac for basic security hygiene. [![Open-Source Software][OSS Icon]](https://github.com/paretoSecurity/pareto-mac/)
+* [PureSnitch](https://github.com/momenbasel/puresnitch) - Free, open-source application firewall for macOS. Little Snitch-style world map, rules manager, DNS over HTTPS, pf-based blocking, no telemetry. [![Open-Source Software][OSS Icon]](https://github.com/momenbasel/puresnitch) ![Freeware][Freeware Icon]
 * [santa](https://github.com/google/santa) - A binary whitelisting/blacklisting system. [![Open-Source Software][OSS Icon]](https://github.com/google/santa) ![Freeware][Freeware Icon]
 * [Shimo](https://www.shimovpn.com) - Fully-featured VPN client for Mac.
 * [SimpleumSafe](https://simpleum.com/) - Encrypt, organize and sync files with macOS or iOS.


### PR DESCRIPTION
Adds PureSnitch to the **Security** section.

PureSnitch is a free, open-source application firewall for macOS. Native SwiftUI, Little Snitch-style world map, rules manager, DNS over HTTPS, pf-based IP/CIDR/port blocking, no telemetry. MIT licensed, signed and notarized by Apple.

- Repo: https://github.com/momenbasel/puresnitch
- License: MIT
- Platform: macOS 14+