### PR TITLE
Add TokenTracker to ### Developers

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@
 - [Swiftify](https://objectivec2swift.com/#/xcode-extension/) - Objective-C to Swift code converter and Xcode & Finder extensions.
 - [TablePlus](https://tableplus.com/) - A modern, native GUI for multiple databases.
 - [TablePro](https://tablepro.app) - A native database client for MySQL, PostgreSQL, SQLite, MongoDB, Redis, and more. [![Open-Source Software][OSS Icon]](https://github.com/TableProApp/TablePro) ![Freeware][Freeware Icon]
+- [TokenTracker](https://github.com/mm7894215/TokenTracker) - Menu-bar dashboard that auto-tracks token usage and cost across 22 AI coding CLIs (Claude Code, Codex, Cursor, Gemini, etc). 100% local, no API keys.
 - [Touch Bar Simulator](https://github.com/sindresorhus/touch-bar-simulator) - The macOS Touch Bar Simulator as a standalone app. [![Open-Source Software][OSS Icon]](https://github.com/sindresorhus/touch-bar-simulator) ![Freeware][Freeware Icon]
 - [Tower](https://www.git-tower.com/) - The most powerful Git client.
 - [Trailer](https://ptsochantaris.github.io/trailer/) - Configurable menubar Git notifications with accompanying native iOS app. [![Open-Source Software][OSS Icon]](https://github.com/ptsochantaris/trailer)


### PR DESCRIPTION
Adding TokenTracker — a local-first CLI + macOS menu bar app that tracks
token usage and cost across 22 AI coding tools (Claude Code, Codex, Cursor,
Gemini CLI, Antigravity, Kiro, OpenCode, GitHub Copilot, Kimi, Grok, and
more).

- 100% local, no API keys, prompts never read or uploaded
- MIT licensed, actively maintained (v0.24.6 released 2026-05-25)
- Featured in 阮一峰科技爱好者周刊 #393 (2026-05-23)
- Repo: https://github.com/mm7894215/TokenTracker
- Site: https://www.tokentracker.cc

Followed the list convention: alphabetical position (between TablePro and
Touch Bar Simulator under ### Developers), link verified, one-line
description matching surrounding entries.