### PR TITLE
Add ModelStatus to Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,7 @@
 - [Media Converter](http://media-converter.sourceforge.net/) - Simple (drag and drop) but advanced media conversion. [![Open-Source Software][OSS Icon]](https://sourceforge.net/p/media-converter/code/ci/master/tree/) ![Freeware][Freeware Icon]
 - [Menubar Colors](https://github.com/nvzqz/Menubar-Colors) - Convenient access to the system color panel. [![Open-Source Software][OSS Icon]](https://github.com/nvzqz/Menubar-Colors) ![Freeware][Freeware Icon]
 - [MenuMeters](http://member.ipmu.jp/yuji.tachikawa/MenuMetersElCapitan/) - A set of CPU, memory, disk, and network monitoring tools for macOS. [![Open-Source Software][OSS Icon]](https://github.com/yujitach/MenuMeters)
+- [ModelStatus](https://github.com/lucasmullikin/ModelStatus) - Menu bar monitor for multiple local LLM servers (Ollama, LM Studio, vLLM, MLX, llama.cpp). Multi-instance, auto-provider-detect, LAN + Tailscale discovery, no telemetry. [![Open-Source Software][OSS Icon]](https://github.com/lucasmullikin/ModelStatus) ![Freeware][Freeware Icon]
 - [MonitorControl](https://github.com/MonitorControl/MonitorControl) - Control your display's brightness and volume on your Mac as if it was a native Apple Display. Use Apple Keyboard keys or custom shortcuts. Shows the native macOS OSDs. [![Open-Source Software][OSS Icon]](https://github.com/MonitorControl/MonitorControl)
 - [Monodraw](http://monodraw.helftone.com/) - A powerful ASCII art editor.
 - [Mounty](http://enjoygineering.com/mounty/) - A tiny tool to re-mount write-protected NTFS volumes under macOS 10.9+ in read-write mode.


### PR DESCRIPTION
Adds ModelStatus to the Applications → Utilities section.

ModelStatus is a free, open-source (MIT) macOS menu bar app for monitoring multiple local LLM servers — Ollama, LM Studio, vLLM, MLX, llama.cpp, and any OpenAI-compatible API. Multi-instance, auto-provider-detect, LAN + Tailscale peer discovery. Pure Swift/AppKit, no dependencies, no telemetry.

- Source: https://github.com/lucasmullikin/ModelStatus
- Install: `brew tap lucasmullikin/tap && brew install --cask modelstatus`
- macOS 13+, MIT license