### PR TITLE
Add usage to Developers

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@
 - [Tower](https://www.git-tower.com/) - The most powerful Git client.
 - [Trailer](https://ptsochantaris.github.io/trailer/) - Configurable menubar Git notifications with accompanying native iOS app. [![Open-Source Software][OSS Icon]](https://github.com/ptsochantaris/trailer)
 - [Unused](https://jeffhodnett.github.io/Unused/) - An app for checking Xcode projects for unused resources. [![Open-Source Software][OSS Icon]](https://github.com/jeffhodnett/Unused) ![Freeware][Freeware Icon]
+- [usage](https://github.com/aqua5230/usage) - Pin Claude Code and Codex quota, tokens, and cost to your menu bar. Local-only — reads a statusLine hook and JSONL session logs; no API calls. [![Open-Source Software][OSS Icon]](https://github.com/aqua5230/usage) ![Freeware][Freeware Icon]
 - [Vagrant Manager](http://vagrantmanager.com) - Manage your vagrant machines in one place with Vagrant Manager for macOS. [![Open-Source Software][OSS Icon]](https://github.com/lanayotech/vagrant-manager/) ![Freeware][Freeware Icon]
 - [Versions](http://versionsapp.com/) - SVN GUI client for Mac.
 - [WWDC](https://github.com/insidegui/WWDC) - The WWDC app. [![Open-Source Software][OSS Icon]](https://github.com/insidegui/WWDC)


### PR DESCRIPTION
<!-- Thanks for contributing to awesome-macOS  -->

0. [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
1. [x] I confirm that I have read and understood the sections about "AI"-adjacent software
2. [x] Project URL: https://github.com/aqua5230/usage
3. [x] Why should this project be added:
   - Native macOS menu bar app (Python + PyObjC), AGPL-3.0
   - 147 ⭐ / 31 forks, actively maintained (currently v0.11.17, regular releases since launch)
   - Solves a concrete developer pain: pins Claude Code and Codex quota / tokens / cost to the menu bar without ever calling the Anthropic or OpenAI API — purely local file reads (statusLine hook + JSONL session logs)
   - Adds value beyond "AI chat client" — it's a quota / cost monitoring utility for developers using AI coding tools
4. [x] End all descriptions with a full stop/period
5. [x] Entry is ordered alphabetically (inserted between `Unused` and `Vagrant Manager`)
6. [x] Appropriate icon(s) added if applicable (OSS, freeware)