### PR TITLE
Add Whisper by Remskill to Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@
 - [Telephone](http://www.64characters.com/telephone/) - A SIP softphone. Make phone calls over the Internet or your company’s network. [![Open-Source Software][OSS Icon]](https://github.com/eofster/Telephone) ![Freeware][Freeware Icon]
 - [TextExpander](https://smilesoftware.com/textexpander) - Create custom keyboard shortcuts for frequently-used text and pictures.
 - [Timing](https://timingapp.com/) - Automatic time and productivity tracking for Mac. Helps you stay on track with your work and ensures no billable hours get lost if you are billing hourly.
+- [Whisper by Remskill](https://whisper.remskill.com) - Hotkey voice-to-text with real-time web search; local Whisper or Parakeet, or cloud OpenAI, pasted at the cursor in any app. ![Freeware][Freeware Icon]
 
 
 ### Sharing Files


### PR DESCRIPTION
Adds **Whisper by Remskill** — a hotkey-driven productivity app for macOS (Apple Silicon) that lets you speak instead of type, with built-in real-time web search.

**Why Productivity (not Audio):** the app is fundamentally about getting text into any app faster — press hotkey, speak, transcription pastes at the cursor. Same shape as Karabiner, TextExpander, PopClip, or Paste in this section. Audio is the input method; productivity is the value. The existing Audio section is geared toward noise removal / TTS (krisp, Murmur), which is a different category.

**What it does:**
- Hotkey → speak → transcription pasted at the cursor in any app
- Real-time web search: speak a question, get the answer pasted
- Three engines: local Whisper, local Parakeet (NVIDIA TDT), or cloud OpenAI — user picks per task
- Free for the entire local pipeline (Freeware badge); Pro tier for cloud features

- Homepage: https://whisper.remskill.com
- Platform: macOS Apple Silicon (Windows also available)

Disclosure: I'm the maintainer.