### PR TITLE
Add Markup to Editors

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@
 - [Emacs](https://www.emacswiki.org/emacs/EmacsForMacOS) - Port of Emacs to work as an macOS app. [![Open-Source Software][OSS Icon]](https://emacsformacosx.com/download/emacs-sources/) ![Freeware][Freeware Icon]
 - [Itsypad](https://itsypad.app) - Lightweight scratchpad with syntax highlighting for 185+ languages and clipboard history manager. [![Open-Source Software][OSS Icon]](https://github.com/nickustinov/itsypad-macos) ![Freeware][Freeware Icon]
 - [MacVim](https://github.com/macvim-dev/macvim) - Vim, the text editor. [![Open-Source Software][OSS Icon]](https://github.com/macvim-dev/macvim) ![Freeware][Freeware Icon]
+- [Markup](https://github.com/oratis/Markup) - Reader-first, native macOS Markdown editor: renders notes like a web page and edits on demand, with a vault, backlinks, graph view and full-text search. [![Open-Source Software][OSS Icon]](https://github.com/oratis/Markup) ![Freeware][Freeware Icon]
 - [Nova](https://nova.app/) - The beautiful, fast, flexible, native Mac code editor from Panic.
 - [Sublime Text 3](http://www.sublimetext.com/) - The sophisticated text editor.
 - [TextMate](https://macromates.com/) - A graphical text editor. [![Open-Source Software][OSS Icon]](https://github.com/textmate/textmate)


### PR DESCRIPTION
Adds **Markup** to the **Editors** section.

- **Repo:** https://github.com/oratis/Markup
- **What it is:** a free, open-source (MIT), native macOS Markdown editor built on Tauri.
- **Why it fits:** reader-first — it renders your Markdown like a clean web page by default and you edit on demand (WYSIWYG or raw source). Includes a vault with wikilinks/backlinks, a graph view, and full-text search.

Entry placed alphabetically between `MacVim` and `Nova`, with the open-source and freeware icons, matching the existing entry format.