### PR TITLE
Add ChargeWatch to Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@
 - [BitBar](https://github.com/matryer/bitbar) - Display output of any script to the menu bar. [![Open-Source Software][OSS Icon]](https://github.com/matryer/bitbar) ![Freeware][Freeware Icon]
 - [Boring Notch](https://github.com/TheBoredTeam/boring.notch) - Turns your MacBook notch into a dynamic hub with media controls, calendar integration, and more. [![Open-Source Software][OSS Icon]](https://github.com/TheBoredTeam/boring.notch) ![Freeware][Freeware Icon]
 - [Burn](http://burn-osx.sourceforge.net/Pages/English/home.html) - No-nonsense burning of Data/Audio/Video CDs and DVDs, including copying. [![Open-Source Software][OSS Icon]](https://sourceforge.net/p/burn-osx/code-git/ci/master/tree/) ![Freeware][Freeware Icon]
+- [ChargeWatch](https://github.com/TY-teo/ChargeWatching) - Menu bar charging power monitor with a built-in battery charge limit for Apple Silicon. Stops charging at the limit while keeping the adapter connected, so the battery is held steady without being discharged. [![Open-Source Software][OSS Icon]](https://github.com/TY-teo/ChargeWatching) ![Freeware][Freeware Icon]
 - [CheatSheet](https://www.cheatsheetapp.com/CheatSheet/) - Know your short cuts. ![Freeware][Freeware Icon]
 - [ClipboardCleaner](https://github.com/Zuehlke/Clipboard_Cleaner) - Automatically removes text formatting from the clipboard. [![Open-Source Software][OSS Icon]](https://github.com/Zuehlke/Clipboard_Cleaner) ![Freeware][Freeware Icon]
 - [CommandQ](https://clickontyler.com/commandq/) - Never accidentally quit an app again.


### PR DESCRIPTION
Hi maintainers, thanks for curating this list.

I'd like to add ChargeWatch to the **Utilities** section.

ChargeWatch is a free, open-source (MIT) menu bar app for Apple Silicon Macs that combines two things in one place:

- Real-time charging power monitor in the menu bar (charge into battery, system load, wall output), computed from instantaneous voltage and current sampled at about 1 Hz — no adapter nameplate estimates.
- Battery charge limit. On Apple Silicon, it stops charging while keeping the adapter connected, so the battery is held steady at the limit instead of being discharged. A free open-source alternative to AlDente, and can hold limits below 80% which the native macOS limit cannot.

Inserted alphabetically between Burn and CheatSheet. The new entry follows the file's existing format (OSS + Freeware badges).

Repo: https://github.com/TY-teo/ChargeWatching
License: MIT