### PR TITLE
Add StayAwake to Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,6 +355,7 @@
 - [Rectangle](https://rectangleapp.com/) - Easily organize windows without using a mouse. [![Open-Source Software][OSS Icon]](https://github.com/rxhanson/Rectangle) ![Freeware][Freeware Icon]
 - [ShiftPlus](https://shiftplus.app/) - macOS workspace manager to switch workspaces, restore apps and windows across Spaces, monitors, and Macs in one click.
 - [Stay](https://cordlessdog.com/stay/) - Resize/position windows when displays change.
+- [StayAwake](https://github.com/TY-teo/StayAwake) - Menu bar app that keeps a MacBook awake while Claude Code, Codex, and Cursor finish long agent runs - including with the lid closed. One-time sudoers rule scoped to two pmset commands, IOPMAssertion-based, timed auto-off. [![Open-Source Software][OSS Icon]](https://github.com/TY-teo/StayAwake) ![Freeware][Freeware Icon]
 - [Swish](https://highlyopinionated.co/swish/) - Control windows and applications with trackpad gestures.
 - [yabai](https://github.com/koekeishiya/yabai) - Tiling window manager with focus follows mouse. [![Open-Source Software][OSS Icon]](https://github.com/koekeishiya/yabai) ![Freeware][Freeware Icon]
 


### PR DESCRIPTION
Hello,

I'd like to suggest **StayAwake** for the **Utilities** section.

StayAwake is an MIT-licensed SwiftUI menu bar app aimed at one specific scenario the existing "keep awake" tools do not directly cover: AI coding agents (Claude Code, OpenAI Codex, Cursor) running long, sometimes overnight tasks on a MacBook with the lid closed.

**Why I think it is a useful addition next to existing entries:**

- KeepingYouAwake (currently listed) explicitly disables itself when the lid is closed — out of scope by design.
- Caffeine is the classic idle-sleep blocker and does not handle clamshell.
- Amphetamine handles clamshell but is closed-source, Mac App Store sandboxed, and has no AI-agent-aware messaging.

**What StayAwake actually does** (verified from the repo, not marketing):

- Two separate `IOPMAssertion`s (`PreventUserIdleSystemSleep` + `PreventUserIdleDisplaySleep`), composed per a `DisplayPolicy`.
- Lid-close support is delegated to `/usr/bin/pmset -a disablesleep 1|0` behind a `PrivilegedRunner` protocol. `AdaptivePrivilegedRunner` first tries `sudo -n`, then falls back to an admin prompt.
- Optional one-time `/etc/sudoers.d/stayawake` rule scoped exactly to those two commands, installed via `visudo -cf` validation, `chown root:wheel`, `chmod 0440`, atomic `mv`, and a final `visudo -c` recheck.
- Timed auto-off (30 / 60 / 120 / 300 min or indefinite), login-item support via `SMAppService.mainApp`, crash-safe reconciliation on launch.

Honest about limits: ad-hoc signed (not notarized yet), and on Apple Silicon the lid-magnet sleep is partially hardware-gated.

Entry inserted near Stay (the existing "keep windows in place" tool) so readers can distinguish them at a glance. Happy to tweak the entry to match the list's format.

Thanks for considering it.