### PR TITLE
Add Sleepless

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,7 @@
 - [SaneBar](https://sanebar.com) - Native menu bar manager with quick reveal controls and Touch ID lock.
 - [Site Sucker](http://ricks-apps.com/osx/sitesucker/) - Automatically download websites from the Internet.
 - [ShiftIt](https://github.com/fikovnik/ShiftIt) - Managing windows size and position. [![Open-Source Software][OSS Icon]](https://github.com/fikovnik/ShiftIt) ![Freeware][Freeware Icon]
+- [Sleepless](https://github.com/Aboudjem/Sleepless) - Menu bar utility that keeps your MacBook awake with the lid closed on battery, with a battery-floor auto-off. [![Open-Source Software][OSS Icon]](https://github.com/Aboudjem/Sleepless) ![Freeware][Freeware Icon]
 - [SlowQuitApps](https://github.com/dteoh/SlowQuitApps) - Prevent accidental Cmd-Q. [![Open-Source Software][OSS Icon]](https://github.com/dteoh/SlowQuitApps) ![Freeware][Freeware Icon]
 - [SmartCapsLock](https://kishanbagaria.com/smartcapslock/) - Makes the Caps Lock key smarter, so that when the key accidentally gets activated and you START YELLING even though you don't want to, you can just select the yelling-text and press the key again to instantly fix its case instead of typing everything all over again.
 - [Soulver](http://www.acqualia.com/soulver/) - Beautiful expressive calculator.


### PR DESCRIPTION
0. [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
1. [x] I confirm that I have read and understood the sections about "AI"-adjacent software
2. [x] Project URL: https://github.com/Aboudjem/Sleepless
3. [x] Why should this project be added: Sleepless is an open-source (MIT), native Swift/AppKit menu bar utility that keeps a MacBook awake with the lid closed, on battery, with no external display, using `pmset disablesleep`, plus a battery-floor auto-off so it stops draining the battery. It is a native AppKit app (not Electron) and complements the already-listed KeepingYouAwake, which intentionally does not keep a Mac awake with the lid closed.
4. [x] End all descriptions with a full stop/period
5. [x] Entry is ordered alphabetically (inserted between ShiftIt and SlowQuitApps in Utilities)
6. [x] Appropriate icon(s) added if applicable (OSS, freeware)