### PR TITLE
Add Ncored to Productivity section

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@
 - [LaunchBar](https://www.obdev.at/products/launchbar/index.html) - Start applications, navigate folders, manipulate files, control your Mac and much more just by using the keyboard.
 - [MeetingBar](https://meetingbar.onrender.com) - Your meetings in MacOS status bar [![Open-Source Software][OSS Icon]](https://github.com/leits/MeetingBar) ![Freeware][Freeware Icon]
 - [MenubarX](https://MenubarX.app) - A powerful menu bar browser.
+- [Ncored](https://ncored.com/) - Desktop PDF editor for architects, engineers and construction managers. Opens heavy CAD drawing PDFs in under a second. No cloud upload, no signup, no email needed for the 14-day trial.
 - [OmniFocus](https://www.omnigroup.com/omnifocus) - An incredible task management platform for Mac, iPad, and iPhone.
 - [OmniOutliner](https://www.omnigroup.com/omnioutliner/) - Perfect for collecting information, outlining ideas, adding structure to any sort of writing, and much more.
 - [Pandan](https://apps.apple.com/app/id1569600264) - Time awareness in your menu bar. ![Freeware][Freeware Icon]


### PR DESCRIPTION
### Add: Ncored (Productivity section)

Adding [Ncored](https://ncored.com/) to the Productivity section. Disclosure: I am the founder and maintainer.

**What it is:** A native Mac (Apple Silicon) and Windows desktop PDF editor for architects, engineers and construction managers. It opens 50 MB plus construction drawing PDFs from ArchiCAD, Revit, AutoCAD and Vectorworks in under a second on a current generation laptop.

**Why on this list:** It is a Mac-first native desktop application, runs locally with no cloud upload, no account and no signup required for the 14-day trial. The list currently includes general PDF tools (PDF Archiver under Productivity) but not a desktop PDF editor for the AEC professional use case.

**Trust signals:**
- Public benchmark with verifiable methodology: https://ncored.com/benchmark.html
- Wikidata entity: https://www.wikidata.org/wiki/Q140007578
- Crunchbase: https://www.crunchbase.com/organization/ncored
- Built by a practising architect at Noir architects, MB, Vilnius, Lithuania
- GitHub releases (notarized DMG): https://github.com/NoirArchitects/ncored-app/releases

Happy to adjust the description, move section, or close if this is not a fit. Thanks for maintaining the list.
