### PR TITLE
Add Rockxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@
 - [PSequel](http://www.psequel.com/) - A PostgreSQL GUI tool. ![Freeware][Freeware Icon]
 - [QorumLogs](https://github.com/goktugyil/QorumLogs) - Swift Logging Utility for Xcode & Google Docs. [![Open-Source Software][OSS Icon]](https://github.com/goktugyil/QorumLogs) ![Freeware][Freeware Icon]
 - [Quiver](http://happenapps.com/#quiver) - A delightful notebook for programmers that allows mixing rich text, code, markdown, LaTeX, and graphs.
+- [Rockxy](https://rockxy.io/) - A native HTTP debugging proxy to capture, inspect, and modify HTTP/HTTPS, WebSocket, and GraphQL traffic. [![Open-Source Software][OSS Icon]](https://github.com/RockxyApp/Rockxy)
 - [Sequel Ace](https://github.com/Sequel-Ace/Sequel-Ace) - A MySQL & MariaDB database manager. [![Open-Source Software][OSS Icon]](https://github.com/Sequel-Ace/Sequel-Ace) ![Freeware][Freeware Icon]
 - [Sequel Pro](http://www.sequelpro.com/) - A MySQL database manager. [![Open-Source Software][OSS Icon]](https://github.com/sequelpro/sequelpro) ![Freeware][Freeware Icon]
 - [SnippetsLab](https://www.renfei.org/snippets-lab/) - Manage and organise snippets of code.


### PR DESCRIPTION
0. [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
1. [x] I confirm that I have read and understood the sections about "AI"-adjacent software
2. [x] Project URL: https://rockxy.io/
3. [x] Why should this project be added: Rockxy is a native, open-source (AGPL-3.0) HTTP debugging proxy for macOS that captures, inspects, and modifies HTTP/HTTPS, WebSocket, and GraphQL traffic. It fits the Developers category alongside tools like Proxyman, and its free open-source core lets maintainers build and validate it without a paywall.
4. [x] End all descriptions with a full stop/period
5. [x] Entry is ordered alphabetically (Developers section, between Quiver and Sequel Ace)
6. [x] Appropriate icon(s) added if applicable (OSS, freeware): OSS icon added and links to the source repository. No freeware icon, as Pro is paid.