### PR TITLE
Add Dusty to Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@
 - [Deliveries](http://junecloud.com/software/mac/deliveries.html) - Beautiful and simple package tracking.
 - [DisableMonitor](https://github.com/Eun/DisableMonitor) - Easily disable or enable a monitor on your Mac. [![Open-Source Software][OSS Icon]](https://github.com/Eun/DisableMonitor) ![Freeware][Freeware Icon]
 - [Dozer](https://github.com/Mortennn/Dozer) - Hide MacOS menubar items. [![Open-Source Software][OSS Icon]](https://github.com/Mortennn/Dozer) ![Freeware][Freeware Icon]
+- [Dusty](https://github.com/yagcioglutoprak/dusty) - Open-source menu bar disk cleaner that only deletes from a fixed allowlist and shows every path and size before removing it. [![Open-Source Software][OSS Icon]](https://github.com/yagcioglutoprak/dusty) ![Freeware][Freeware Icon]
 - [EtreCheck](http://etrecheck.com) - Output system information and configuration to get more informed help from Apple support professionals. ![Freeware][Freeware Icon]
 - [Equinox](https://equinoxmac.com) - Create macOS dynamic wallpapers. [![Open-Source Software][OSS Icon]](https://github.com/rlxone/Equinox) ![Freeware][Freeware Icon]
 - [Fanny](http://fannywidget.com/) - Notification Center widget and menu bar application to monitor your Mac's fans and CPU temperature. [![Open-Source Software][OSS Icon]](https://github.com/DanielStormApps/Fanny) ![Freeware][Freeware Icon]


### PR DESCRIPTION
Adds Dusty, a free and open-source (MIT) macOS menu bar disk cleaner, to the Utilities section (alphabetically after Dozer).

It reclaims space from caches, logs, and developer junk and is built so it can only ever delete from a fixed allowlist: it shows every path and its size before removing anything, supports a dry run, can move to Trash with undo, and writes a deletion log. The deletion engine is a separate, unit-tested Swift package. Signed and notarized by Apple.

Repo: https://github.com/yagcioglutoprak/dusty

One line, alphabetical placement, standard OSS + Freeware badges, matching the existing entries (similar in spirit to the existing PureMac entry).