### PR TITLE
Add Gantry

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@
 - [Decode](https://microcodingapps.com/products/decode.html) - Converts Xcode Interface Builder files (Xib and Storyboard files) to Swift source code.
 - [Fork](https://git-fork.com/) - a fast and friendly git client for Mac.
 - [DevUtils](https://devutils.com) - All-in-one toolbox for developers. 42+ beautifully crafted useful developer tools, native macOS app, work offline.
+- [Gantry](https://getgantry.github.io/) - Native Docker management: containers, images, live logs and stats, exec terminal — local and over SSH. [![Open-Source Software][OSS Icon]](https://github.com/getgantry/gantry) ![Freeware][Freeware Icon]
 - [Gas Mask](https://github.com/2ndalpha/gasmask) - A simple hosts file manager which allows editing of host files and switching between them. [![Open-Source Software][OSS Icon]](https://github.com/2ndalpha/gasmask) ![Freeware][Freeware Icon]
 - [gitbar](https://github.com/Shikkic/gitbar) - Open source github contribution stats on your Menu Bar. [![Open-Source Software][OSS Icon]](https://github.com/Shikkic/gitbar) ![Freeware][Freeware Icon]
 - [GitUp](http://gitup.co/) - A simple but powerful Git macOS app. [![Open-Source Software][OSS Icon]](https://github.com/git-up/GitUp) ![Freeware][Freeware Icon]


### PR DESCRIPTION
Adds [Gantry](https://getgantry.github.io/) to Applications → Developers (alphabetical order).

Gantry is a free, MIT-licensed, fully native macOS app (SwiftUI) for managing and monitoring Docker — containers, images, volumes, networks, live logs, stats charts, exec terminal and a file browser — for local and remote (SSH) hosts, with a fleet dashboard, Shortcuts/Siri support and a bundled MCP server.

Source: https://github.com/getgantry/gantry