### PR TITLE
Add LanGuard to Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,7 @@
 - [KeepingYouAwake](https://github.com/newmarcel/KeepingYouAwake) - Menu bar utility that prevents Mac from going to sleep. [![Open-Source Software][OSS Icon]](https://github.com/newmarcel/KeepingYouAwake) ![Freeware][Freeware Icon]
 - [Keka](https://www.keka.io/) - Compress to and extract from many archive file formats. ![Freeware][Freeware Icon]
 - [Knock](http://www.knocktounlock.com) - Unlock your Mac quickly and securely. ![Freeware][Freeware Icon]
+- [LanGuard](https://github.com/roypadina/LanGuard) - Turns Wi-Fi off when a wired Ethernet link is active, back on when unplugged. Edge-based, wake-aware, no admin rights. [![Open-Source Software][OSS Icon]](https://github.com/roypadina/LanGuard) ![Freeware][Freeware Icon]
 - [LaunchControl](http://www.soma-zone.com/LaunchControl/) - Create, manage and debug launchd services. ![Freeware][Freeware Icon]
 - [Loading](http://bonzaiapps.com) - See when apps are using your network in your Mac menubar. [![Open-Source Software][OSS Icon]](https://github.com/BonzaiThePenguin/Loading/) ![Freeware][Freeware Icon]
 - [Little Snitch](https://www.obdev.at/products/littlesnitch/index.html) - Protect your privacy.


### PR DESCRIPTION
Adds **LanGuard** to the Utilities section (kept alphabetical; description ends with a period).

LanGuard is a free, open-source (MIT) macOS menu-bar app that turns Wi-Fi off when a wired Ethernet link is active and back on when you unplug — edge-based, wake-aware, per-interface, no admin rights.

Repo: https://github.com/roypadina/LanGuard