### PR TITLE
Add TopOff

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@
 - [Swiftify](https://objectivec2swift.com/#/xcode-extension/) - Objective-C to Swift code converter and Xcode & Finder extensions.
 - [TablePlus](https://tableplus.com/) - A modern, native GUI for multiple databases.
 - [TablePro](https://tablepro.app) - A native database client for MySQL, PostgreSQL, SQLite, MongoDB, Redis, and more. [![Open-Source Software][OSS Icon]](https://github.com/TableProApp/TablePro) ![Freeware][Freeware Icon]
+- [TopOff](https://github.com/ihazgithub/TopOff) - Menu bar app for Homebrew — full beer mug when packages are fresh, half mug when it's time to refill. [![Open-Source Software][OSS Icon]](https://github.com/ihazgithub/TopOff) ![Freeware][Freeware Icon]
 - [Touch Bar Simulator](https://github.com/sindresorhus/touch-bar-simulator) - The macOS Touch Bar Simulator as a standalone app. [![Open-Source Software][OSS Icon]](https://github.com/sindresorhus/touch-bar-simulator) ![Freeware][Freeware Icon]
 - [Tower](https://www.git-tower.com/) - The most powerful Git client.
 - [Trailer](https://ptsochantaris.github.io/trailer/) - Configurable menubar Git notifications with accompanying native iOS app. [![Open-Source Software][OSS Icon]](https://github.com/ptsochantaris/trailer)


### PR DESCRIPTION
0. [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
1. [x] I confirm that I have read and understood the sections about "AI"-adjacent software
2. [x] Project URL: https://github.com/ihazgithub/TopOff
3. [x] Why should this project be added: TopOff is an open-source SwiftUI menu bar app that keeps macOS users' Homebrew packages up to date. Full beer mug in the menu bar when packages are fresh, half mug when it's time to refill. Free, MIT licensed, signed and notarized, universal binary, macOS 14+.
4. [x] End all descriptions with a full stop/period
5. [x] Entry is ordered alphabetically (Developers section, between TablePro and Touch Bar Simulator)
6. [x] Appropriate icon(s) added if applicable (OSS, freeware)
