### PR TITLE
Add Featherbar

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,7 @@
 - [EtreCheck](http://etrecheck.com) - Output system information and configuration to get more informed help from Apple support professionals. ![Freeware][Freeware Icon]
 - [Equinox](https://equinoxmac.com) - Create macOS dynamic wallpapers. [![Open-Source Software][OSS Icon]](https://github.com/rlxone/Equinox) ![Freeware][Freeware Icon]
 - [Fanny](http://fannywidget.com/) - Notification Center widget and menu bar application to monitor your Mac's fans and CPU temperature. [![Open-Source Software][OSS Icon]](https://github.com/DanielStormApps/Fanny) ![Freeware][Freeware Icon]
+- [Featherbar](https://github.com/nim444/featherbar) - Featherweight menu bar system monitor showing CPU, RAM, power, and temperature in two color-coded lines. [![Open-Source Software][OSS Icon]](https://github.com/nim444/featherbar) ![Freeware][Freeware Icon]
 - [Finicky](https://johnste.github.io/finicky/) - App that allows you to set rules that decide which browser is opened for every link. [![Open-Source Software][OSS Icon]](https://github.com/johnste/finicky) ![Freeware][Freeware Icon]
 - [Flotato](https://flotato.com/) - Use any web site as a beautiful Mac app.
 - [Fluid](http://fluidapp.com/) - Turn web applications into Mac applications.


### PR DESCRIPTION
0. [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
1. [x] I confirm that I have read and understood the sections about "AI"-adjacent software
2. [x] Project URL: https://github.com/nim444/featherbar
3. [x] Why should this project be added: Featherbar is a featherweight, native macOS menu-bar system monitor written in Rust (no Electron). It shows CPU, RAM, power draw, and temperature in two color-coded menu bar lines with zero background threads and flat ~20MB memory use. Open source (Apache-2.0), free, actively maintained, published on crates.io.
4. [x] End all descriptions with a full stop/period
5. [x] Entry is ordered alphabetically (Utilities, before Finicky)
6. [x] Appropriate icon(s) added if applicable (OSS, freeware)