### PR TITLE
Add NetGuard — native macOS network scanner and security auditor

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,6 +444,7 @@ Ansible playbook to configure a development and desktop environment from a clean
 * [macchanger by acrogenesis](https://acrogenesis.com/macchanger/) - Easily change your MAC Address [![Open-Source Software][OSS Icon]](https://github.com/acrogenesis/macchanger) ![Freeware][Freeware Icon]
 * [macchanger by shilch](https://github.com/shilch/macchanger/) - Change / spoof MAC address (random, custom and restore). [![Open-Source Software][OSS Icon]](https://github.com/shilch/macchanger)
 * [MIDAS](https://github.com/etsy/MIDAS) - Intrusion Detection Analysis System. [![Open-Source Software][OSS Icon]](https://github.com/etsy/MIDAS)
+* * [NetGuard](https://github.com/Lyosis/NetGuard) - Native macOS network scanner and security auditor — discover LAN devices, scan ports, inspect SSL certificates, and detect vulnerabilities. [![Open-Source Software][OSS Icon]](https://github.com/Lyosis/NetGuard) ![Freeware][Freeware Icon]
 * [OS-X-Security-and-Privacy-Guide](https://github.com/drduh/OS-X-Security-and-Privacy-Guide) [![Open-Source Software][OSS Icon]](https://github.com/drduh/OS-X-Security-and-Privacy-Guide)
 * [OSXCollector](https://github.com/Yelp/osxcollector) - Forensic evidence collection & analysis toolkit. [![Open-Source Software][OSS Icon]](https://github.com/Yelp/osxcollector) ![Freeware][Freeware Icon]
 * [Pareto Security](https://paretosecurity.app/) - A MenuBar app to automatically audit your Mac for basic security hygiene. [![Open-Source Software][OSS Icon]](https://github.com/paretoSecurity/pareto-mac/)


### PR DESCRIPTION
- [x] I have read the Contribution Guidelines
- [x] I confirm that I have read and understood the sections about "AI"-adjacent software
- [x] Project URL: https://github.com/Lyosis/NetGuard
- [x] Why should this project be added: NetGuard is a native macOS network scanner and security auditor built entirely in SwiftUI/Swift 6. It discovers all devices on the local network via ping sweep, port scan, mDNS/Bonjour, NetBIOS, and SSDP/UPnP; checks for open dangerous ports, expired SSL certificates, and default credentials; and runs a per-device risk score audit — all without sending any data outside the machine. No Electron, no telemetry, no subscription. Apple Silicon only.
- [x] End all descriptions with a full stop/period ✓
- [x] Entry is ordered alphabetically ✓ (between MIDAS and OS-X-Security-and-Privacy-Guide)
- [x] Appropriate icon(s) added if applicable (OSS icon + Freeware icon) ✓