### PR TITLE
Add Git Menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@
 - [Fork](https://git-fork.com/) - a fast and friendly git client for Mac.
 - [DevUtils](https://devutils.com) - All-in-one toolbox for developers. 42+ beautifully crafted useful developer tools, native macOS app, work offline.
 - [Gas Mask](https://github.com/2ndalpha/gasmask) - A simple hosts file manager which allows editing of host files and switching between them. [![Open-Source Software][OSS Icon]](https://github.com/2ndalpha/gasmask) ![Freeware][Freeware Icon]
+- [Git Menu](https://github.com/Artim-Nayas/git-menu) - Your GitHub PRs, reviews, inbox, and Actions in the menu bar, powered by the gh CLI. [![Open-Source Software][OSS Icon]](https://github.com/Artim-Nayas/git-menu) ![Freeware][Freeware Icon]
 - [gitbar](https://github.com/Shikkic/gitbar) - Open source github contribution stats on your Menu Bar. [![Open-Source Software][OSS Icon]](https://github.com/Shikkic/gitbar) ![Freeware][Freeware Icon]
 - [GitUp](http://gitup.co/) - A simple but powerful Git macOS app. [![Open-Source Software][OSS Icon]](https://github.com/git-up/GitUp) ![Freeware][Freeware Icon]
 - [GitX-dev](https://rowanj.github.io/gitx/) - A fork (variant) of GitX, maintained and enhanced with productivity oriented changes.  [![Open-Source Software][OSS Icon]](https://github.com/rowanj/gitx) ![Freeware][Freeware Icon]


### PR DESCRIPTION
Adds **[Git Menu](https://github.com/Artim-Nayas/git-menu)** to the *Developers* section (placed alphabetically, between Gas Mask and gitbar — sits well next to gitbar and Trailer).

Git Menu is a lightweight, open-source (MIT) macOS menu-bar app for your GitHub work — pull requests, review requests, a notifications inbox, GitHub Actions runs, and your contribution streak — powered entirely by the `gh` CLI. English README with a screenshot/animated demo; ships a macOS binary (`.dmg` + Homebrew cask).

- Open source: https://github.com/Artim-Nayas/git-menu
- Marked Open-Source + Freeware, matching nearby entries.