### PR TITLE
Add Zenithal

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@
 - [Versions](http://versionsapp.com/) - SVN GUI client for Mac.
 - [WWDC](https://github.com/insidegui/WWDC) - The WWDC app. [![Open-Source Software][OSS Icon]](https://github.com/insidegui/WWDC)
 - [Xcodes](https://github.com/RobotsAndPencils/XcodesApp) - Install and switch between multiple versions of Xcode. [![Open-Source Software][OSS Icon]](https://github.com/RobotsAndPencils/XcodesApp) ![Freeware][Freeware Icon]
+- [Zenithal](https://www.empiricapps.com/zenithal) - Native GUI for managing Docker containers, Compose stacks, and Kubernetes, with image vulnerability scanning.
 
 
 ### E-Book Utilities


### PR DESCRIPTION
Zenithal is a native macOS GUI for managing Docker containers, Compose stacks, and Kubernetes, with built-in image vulnerability scanning. Added to Developers in alphabetical order.

Site: https://www.empiricapps.com/zenithal