### PR TITLE
Add EmpiricCommander

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@
 
 ### Finder
 
+- [EmpiricCommander](https://www.empiricapps.com/empiric-commander) - Dual-pane file manager with SFTP, batch renaming, and Docker container file browsing.
 - [ForkLift](https://itunes.apple.com/us/app/forklift-file-manager-ftp/id412448059) - File Manager and FTP/SFTP/WebDAV/Amazon S3 client.
 - [Path Finder](http://www.cocoatech.com/pathfinder/) - A powerful dual-pane browser alternative to Finder.
 - [Quicklook-Plugins](https://github.com/sindresorhus/quick-look-plugins) - List of extra quicklook plugins to enable previewing more filetypes in the Finder.


### PR DESCRIPTION
EmpiricCommander is a native dual-pane file manager for macOS with SFTP/FTP, pattern-based batch renaming, and the ability to browse files inside Docker containers (alongside the existing ForkLift / Path Finder entries). Added to Finder in alphabetical order.

Site: https://www.empiricapps.com/empiric-commander