### PR TITLE
Add pyimgtag to Command Line Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,6 +376,7 @@
 - [Mac-CLI](https://github.com/guarinogabriel/Mac-CLI) -  macOS command line tools for developers.
 - [Mocker](https://github.com/us/mocker) - Docker-compatible container CLI for macOS, built on Apple's Containerization framework. [![Open-Source Software][OSS Icon]](https://github.com/us/mocker) ![Freeware][Freeware Icon]
 - [mas](https://github.com/mas-cli/mas) - A CLI for the Mac App Store. [![Open-Source Software][OSS Icon]](https://github.com/mas-cli/mas) ![Freeware][Freeware Icon]
+- [pyimgtag](https://github.com/kurok/pyimgtag) - Command-line photo tagger that uses a local vision model (Gemma via Ollama by default) to add searchable tags, scene categories, and EXIF-GPS-derived location to images; reads and writes the Apple Photos library on macOS. [![Open-Source Software][OSS Icon]](https://github.com/kurok/pyimgtag) ![Freeware][Freeware Icon]
 
 ## macOS Utilities
 


### PR DESCRIPTION
<!-- Thanks for contributing to awesome-macOS  -->

<!-- Please fill out the following: -->

0. [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
1. [x] I confirm that I have read and understood the sections about "AI"-adjacent software
2. [x] Project URL: https://github.com/kurok/pyimgtag
3. [x] Why should this project be added: pyimgtag is a free, open-source macOS command-line tool that tags photos by running a local on-device vision model (Gemma via Ollama). The primary product is photo library management — the ML model is an internal component for scene understanding, analogous to a "smart repair brush" in an image editor. It reads and writes the Apple Photos library on macOS, adds searchable keyword tags, scene categories, and reverse-geocoded location from EXIF GPS data. It does not require internet access by default; cloud backends (Anthropic/OpenAI/Gemini) are optional via `--backend`.
4. [x] End all descriptions with a full stop/period
5. [x] Entry is ordered alphabetically (after `mas`, before the next section — `p` > `m`)
6. [x] Appropriate icon(s) added if applicable (OSS icon + Freeware icon — MIT-licensed, free)