### PR TITLE
Add Headroom to Developers

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@
 - [gitbar](https://github.com/Shikkic/gitbar) - Open source github contribution stats on your Menu Bar. [![Open-Source Software][OSS Icon]](https://github.com/Shikkic/gitbar) ![Freeware][Freeware Icon]
 - [GitUp](http://gitup.co/) - A simple but powerful Git macOS app. [![Open-Source Software][OSS Icon]](https://github.com/git-up/GitUp) ![Freeware][Freeware Icon]
 - [GitX-dev](https://rowanj.github.io/gitx/) - A fork (variant) of GitX, maintained and enhanced with productivity oriented changes.  [![Open-Source Software][OSS Icon]](https://github.com/rowanj/gitx) ![Freeware][Freeware Icon]
+- [Headroom](https://headroom.walls.sh) - Claude Code usage (5h session + 7d week) as a live, color-coded percentage in the menu bar. [![Open-Source Software][OSS Icon]](https://github.com/patwalls/headroom) ![Freeware][Freeware Icon]
 - [Hopper Dissassembler](https://www.hopperapp.com) - A Dissassembler for MacOS and Linux. Has a Demo option for 30 minutes of productivity.
 - [Hosts](https://github.com/specialunderwear/Hosts.prefpane) - Edit hosts file. [![Open-Source Software][OSS Icon]](https://github.com/specialunderwear/Hosts.prefpane) ![Freeware][Freeware Icon]
 - [Iconology](https://github.com/liamrosenfeld/Iconology) - Edit Icons and then Export to Xcode, Icns, Ico, Favicon, Mac Iconset, or a Custom List of Sizes. [![Open-Source Software][OSS Icon]](https://github.com/liamrosenfeld/Iconology) ![Freeware][Freeware Icon]


### PR DESCRIPTION
Adds [Headroom](https://headroom.walls.sh) — a free, native macOS menu bar app showing Claude Code usage (the 5-hour session and 7-day weekly limits) as a live, color-coded percentage with reset countdowns. Zero config, zero network calls: it reads usage numbers from a local file Claude Code's own status line writes to `~/.claude/headroom-usage.json` — no API key, no Keychain, no network requests ever. MIT licensed ([source](https://github.com/patwalls/headroom)), ~780 lines of dependency-free AppKit Swift, signed & notarized.

Placed alphabetically in Developers (alongside gitbar, the other dev menu bar tool there). OSS + Freeware icons per the section's convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)