### PR TITLE
Add Whisper by Remskill to Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@
 - [Telephone](http://www.64characters.com/telephone/) - A SIP softphone. Make phone calls over the Internet or your company’s network. [![Open-Source Software][OSS Icon]](https://github.com/eofster/Telephone) ![Freeware][Freeware Icon]
 - [TextExpander](https://smilesoftware.com/textexpander) - Create custom keyboard shortcuts for frequently-used text and pictures.
 - [Timing](https://timingapp.com/) - Automatic time and productivity tracking for Mac. Helps you stay on track with your work and ensures no billable hours get lost if you are billing hourly.
+- [Whisper by Remskill](https://whisper.remskill.com) - Hotkey voice-to-text dictation; speak and polished text is pasted at your cursor in any app, offline with local Whisper/Parakeet or via OpenAI cloud. ![Freeware][Freeware Icon]
 
 
 ### Sharing Files


### PR DESCRIPTION
Adds **Whisper by Remskill** to the end of the **Productivity** section (alphabetical), tagged Freeware.A macOS (Apple Silicon) voice-to-text dictation app: press a global hotkey, speak, and polished text is pasted at your cursor in any app. Transcribes fully offline with local Whisper / NVIDIA Parakeet engines, or via OpenAI cloud. The entire local pipeline is free (Freeware icon; no credit card at signup).- One item, no unrelated changes