### PR TITLE
Add Ghostwriter to Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@
 - [Dropzone](https://aptonic.com/) - Create a popup grid of customizable actions that enhance productivity on your Mac.
 - [f.lux](https://justgetflux.com/) - Automatically adjust your computer screen to match lighting. ![Freeware][Freeware Icon]
 - [Fantastical](https://flexibits.com/fantastical) - Complete Calendar app replacement which uses natural language for creating events.
+- [Ghostwriter](https://evanpizzolato.github.io/ghostwriter/) - Always-on-top notes app for presenters whose notes stay invisible to screenshots, recordings, and screen shares. [![Open-Source Software][OSS Icon]](https://github.com/evanpizzolato/ghostwriter) ![Freeware][Freeware Icon]
 - [Hazel](https://www.noodlesoft.com/hazel.php) - Create rules to automatically keep your files organized.
 - [HazeOver](https://hazeover.com/) - Turn distractions down and focus on your current task.
 - [HyperDock](https://bahoom.com/hyperdock/) - Select individual application window.


### PR DESCRIPTION
## What is this app?

[Ghostwriter](https://evanpizzolato.github.io/ghostwriter/) is a free, open-source ([GPL-3.0](https://github.com/evanpizzolato/ghostwriter/blob/main/LICENSE)) always-on-top notes app for presenters on macOS. Its Privacy mode uses OS-level content protection so notes stay invisible to screenshots, screen recordings, and screen shares (Zoom, Meet, Teams, OBS) while remaining visible to the presenter.

- Website: https://evanpizzolato.github.io/ghostwriter/
- Source: https://github.com/evanpizzolato/ghostwriter
- Signed + notarized universal build (Intel & Apple Silicon), macOS 12+

Entry added alphabetically to the Productivity section with the OSS and Freeware icons per list conventions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)