### PR TITLE
Add Keyholdr to Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,7 @@
 - [Kawa](https://github.com/noraesae/kawa) - A better input source switcher with shortcuts. [![Open-Source Software][OSS Icon]](https://github.com/noraesae/kawa) ![Freeware][Freeware Icon]
 - [KeepingYouAwake](https://github.com/newmarcel/KeepingYouAwake) - Menu bar utility that prevents Mac from going to sleep. [![Open-Source Software][OSS Icon]](https://github.com/newmarcel/KeepingYouAwake) ![Freeware][Freeware Icon]
 - [Keka](https://www.keka.io/) - Compress to and extract from many archive file formats. ![Freeware][Freeware Icon]
+- [Keyholdr](https://github.com/OlixIgnacious/keyholdr) - Menu bar vault for API keys with hardware-backed Keychain storage and Touch ID unlock. [![Open-Source Software][OSS Icon]](https://github.com/OlixIgnacious/keyholdr) ![Freeware][Freeware Icon]
 - [Knock](http://www.knocktounlock.com) - Unlock your Mac quickly and securely. ![Freeware][Freeware Icon]
 - [LaunchControl](http://www.soma-zone.com/LaunchControl/) - Create, manage and debug launchd services. ![Freeware][Freeware Icon]
 - [Loading](http://bonzaiapps.com) - See when apps are using your network in your Mac menubar. [![Open-Source Software][OSS Icon]](https://github.com/BonzaiThePenguin/Loading/) ![Freeware][Freeware Icon]


### PR DESCRIPTION
## Summary
- Adds [Keyholdr](https://github.com/OlixIgnacious/keyholdr), a native macOS menu bar vault for API keys with hardware-backed Keychain storage and Touch ID unlock.

## Checklist
- [x] Entry added in alphabetical order under Utilities
- [x] Uses existing OSS/Freeware icon badges, matching surrounding entries