### PR TITLE
Add Plan4Projects to Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@
 - [Pandan](https://apps.apple.com/app/id1569600264) - Time awareness in your menu bar. ![Freeware][Freeware Icon]
 - [Paste](http://pasteapp.me) - The new way to copy & paste for Mac.
 - [PDF Archiver](https://github.com/JulianKahnert/PDF-Archiver) - A nice tool for tagging and archiving tasks. [![Open-Source Software][OSS Icon]](https://github.com/JulianKahnert/PDF-Archiver)
+- [Plan4Projects](https://plan4projects.com) - Free, native Gantt chart and project planner; a Microsoft Project alternative that opens .mpp files, with a built-in AI assistant. ![Freeware][Freeware Icon]
 - [PopClip](http://pilotmoon.com/popclip/) - Instantly copy & paste, access actions like search, spelling, dictionary and more.
 - [Presentify](https://presentify.compzets.com) - Annotate anything on screen, be it, images, pdfs, videos, code, etc.
 - [Qbserve](https://qotoqot.com/qbserve/) - Automatic time and project tracking, timesheets, invoicing, and real-time productivity feedback.


### PR DESCRIPTION
Adds **Plan4Projects** to the Productivity section (kept in alphabetical order, after PDF Archiver).

Plan4Projects is a free, native macOS Gantt chart and project planner — a Microsoft Project alternative that opens `.mpp` files and exports Project XML, with a built-in (bring-your-own-key) AI assistant. Notarized by Apple and self-updating. https://plan4projects.com

