### PR TITLE
add screenpipe to productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,7 @@
 - [Qbserve](https://qotoqot.com/qbserve/) - Automatic time and project tracking, timesheets, invoicing, and real-time productivity feedback.
 - [Quicksilver](https://qsapp.com/) - Control your Mac quickly and elegantly. [![Open-Source Software][OSS Icon]](https://github.com/quicksilver/Quicksilver) ![Freeware][Freeware Icon]
 - [Rocket](http://matthewpalmer.net/rocket/) - Makes typing emoji faster and easier using Slack-style shortcuts. ![Freeware][Freeware Icon]
+- [screenpipe](https://github.com/screenpipe/screenpipe) - Records your screen and mic 24/7 and indexes everything locally, so you can search your history, recall context, and pipe it into AI. Local-first. [![Open-Source Software][OSS Icon]](https://github.com/screenpipe/screenpipe)
 - [ScreenTranslate](https://screentranslate.filient.ai/) - Capture any area or select text to translate instantly, fully on-device. [![Open-Source Software][OSS Icon]](https://github.com/hcmhcs/screenTranslate) ![Freeware][Freeware Icon]
 - [SelfControl](https://selfcontrolapp.com/) - Block access to distracting websites. [![Open-Source Software][OSS Icon]](https://github.com/SelfControlApp/selfcontrol/) ![Freeware][Freeware Icon]
 - [Simplenote](https://simplenote.com/) - Simple cross-platform note taking app with cloud-based syncing. ![Freeware][Freeware Icon]


### PR DESCRIPTION
adds screenpipe under productivity (alphabetical, before ScreenTranslate). open-source, local-first 24/7 screen + mic recorder you can search and pipe into AI.