### PR TITLE
Add Fabar - per-app volume control for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@
 - [Audio Hijack](http://www.rogueamoeba.com/audiohijack/) - Record audio from any application like iTunes, Skype or Safari, or from hardware devices like microphones and mixers.
 - [Audio Profile Manager](https://apps.apple.com/us/app/audio-profile-manager/id1484150558?ls=1&mt=12) - Allows you to pin input/output devices for each particular combination of connected devices. May suppress HDMI displays from being chosen.
 - [BackgroundMusic](https://github.com/kyleneideck/BackgroundMusic) - Record system audio, control audio levels for individual apps, and automatically pauses your music player when other audio starts playing and unpauses it afterwards. [![Open-Source Software][OSS Icon]](https://github.com/kyleneideck/BackgroundMusic) ![Freeware][Freeware Icon]
+- [Fabar](https://github.com/gigaptera/fabar) - Per-app volume control from the menu bar using Core Audio process taps, no virtual driver needed. [![Open-Source Software][OSS Icon]](https://github.com/gigaptera/fabar) ![Freeware][Freeware Icon]
 - [krisp](https://krisp.ai/) - AI-powered app that removes background noise and echo from meetings leaving only human voice.
 - [Murmur](https://murmurtts.com/) - On-device text-to-speech studio with 860+ voices, voice cloning, and four AI models running entirely on Apple Silicon via MLX.
 - [Plug](https://plugformac.com) - Discover and listen to music from Hype Machine. [![Open-Source Software][OSS Icon]](https://github.com/wulkano/Plug) ![Freeware][Freeware Icon]


### PR DESCRIPTION
**[Fabar](https://github.com/gigaptera/fabar)** — Free, MIT-licensed, open-source per-app volume control for macOS.

- Menu bar app with a volume slider for every app playing audio
- Uses Core Audio process taps (macOS 14.4+) — no virtual audio driver, nothing added to your output device list
- Apps you never adjust stay on the native audio path
- Boost quiet apps up to 200%
- Swift / SwiftUI, signed & notarized DMG

Added to the **Audio** section in alphabetical order.