### PR TITLE
Add DailyDesk to productivity apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@
 - [BetterTouchTool](https://folivora.ai) - Configure gestures for mouse and actions for keyboard shortcuts.
 - [ClipMenu](http://www.clipmenu.com/) - ClipBoard History Manager. [![Open-Source Software][OSS Icon]](https://github.com/naotaka/ClipMenu) ![Freeware][Freeware Icon]
 - [CloudClip](http://www.thinkbitz.com/cloudclip/) - Sync your clipboard between your Mac and your iOS devices. ![Freeware][Freeware Icon]
+- [DailyDesk](https://github.com/StaryMoon/DailyDesk) - Native glass desktop planner with recurring tasks, local rewards, and a tiny desktop pet. [![Open-Source Software][OSS Icon]](https://github.com/StaryMoon/DailyDesk) ![Freeware][Freeware Icon]
 - [Dropzone](https://aptonic.com/) - Create a popup grid of customizable actions that enhance productivity on your Mac.
 - [f.lux](https://justgetflux.com/) - Automatically adjust your computer screen to match lighting. ![Freeware][Freeware Icon]
 - [Fantastical](https://flexibits.com/fantastical) - Complete Calendar app replacement which uses natural language for creating events.


### PR DESCRIPTION
0. [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)\n1. [x] I confirm that I have read and understood the sections about "AI"-adjacent software\n2. Project URL: https://github.com/StaryMoon/DailyDesk\n3. Why should this project be added: DailyDesk is a native Swift/AppKit desktop planner for macOS. It keeps recurring tasks visible on the wallpaper, uses local-only rewards, and includes a tiny desktop pet without Electron or network sync.\n4. [x] End all descriptions with a full stop/period\n5. [x] Entry is ordered alphabetically\n6. [x] Appropriate icon(s) added if applicable (OSS, freeware)