### PR TITLE
Add N1KO-STATE to Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,7 @@
 - [MonitorControl](https://github.com/MonitorControl/MonitorControl) - Control your display's brightness and volume on your Mac as if it was a native Apple Display. Use Apple Keyboard keys or custom shortcuts. Shows the native macOS OSDs. [![Open-Source Software][OSS Icon]](https://github.com/MonitorControl/MonitorControl)
 - [Monodraw](http://monodraw.helftone.com/) - A powerful ASCII art editor.
 - [Mounty](http://enjoygineering.com/mounty/) - A tiny tool to re-mount write-protected NTFS volumes under macOS 10.9+ in read-write mode.
+- [N1KO-STATE](https://github.com/baogutang/N1KO-STATE) - Native Swift menu bar monitor for CPU, GPU, memory, temperature, and fan RPM. Low overhead, open source.
 - [Noizio](http://noiz.io/) - Ambient sound equalizer for relaxation or productivity.
 - [Notational Velocity](http://notational.net/) - Store, retrieve and sync notes within a minimal GUI. [![Open-Source Software][OSS Icon]](https://github.com/scrod/nv/) ![Freeware][Freeware Icon]
 - [Noti](https://noti.center/) - Receive Android notifications on your mac (with PushBullet). [![Open-Source Software][OSS Icon]](https://github.com/jariz/Noti/) ![Freeware][Freeware Icon]


### PR DESCRIPTION
Adding N1KO-STATE — a native Swift macOS menu bar system monitor 
(CPU, GPU, memory, temperature, fan RPM). It's open source, free, 
and has zero Electron/web view overhead.

GitHub: https://github.com/baogutang/N1KO-STATE