### PR TITLE
Add SSH Tunnel Manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,7 @@
 - [SmartCapsLock](https://kishanbagaria.com/smartcapslock/) - Makes the Caps Lock key smarter, so that when the key accidentally gets activated and you START YELLING even though you don't want to, you can just select the yelling-text and press the key again to instantly fix its case instead of typing everything all over again.
 - [Soulver](http://www.acqualia.com/soulver/) - Beautiful expressive calculator.
 - [SSH Tunnel](https://codinn.com/products/ssh-tunnel/) - Manage your SSH tunnels, tightly integrated with macOS Keychain, secure and intuitive.
+- [SSH Tunnel Manager](https://github.com/0fuz/ssh-tunnel-manager) - Menu bar app for managing SSH port forwards (local, remote, SOCKS, jump host) that auto-reconnects when the connection drops. [![Open-Source Software][OSS Icon]](https://github.com/0fuz/ssh-tunnel-manager) ![Freeware][Freeware Icon]
 - [Strongbox](https://strongboxsafe.com/) - Secure Password Management for iOS and MacOS. Open Source. Compatible with KeePass and Password Safe. [![Open-Source Software][OSS Icon]](https://github.com/strongbox-password-safe/Strongbox)
 - [TeamViewer](https://www.teamviewer.com/en/) - Remotely control another computer.
 - [TextBar](http://www.richsomerfield.com/apps/) - TextBar is a tiny but powerful app that lets you add any text to your MenuBar.


### PR DESCRIPTION
Adds SSH Tunnel Manager, an open-source (MIT) macOS menu-bar app for managing SSH port forwards (-L/-R/-D/-J) with auto-reconnect. Native Swift/AppKit, no Electron. Placed in Utilities, alphabetically after the existing SSH Tunnel entry. https://github.com/0fuz/ssh-tunnel-manager