### PR TITLE
Add Painless Belt to Command Line Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,6 +380,7 @@
 - [Mac-CLI](https://github.com/guarinogabriel/Mac-CLI) -  macOS command line tools for developers.
 - [Mocker](https://github.com/us/mocker) - Docker-compatible container CLI for macOS, built on Apple's Containerization framework. [![Open-Source Software][OSS Icon]](https://github.com/us/mocker) ![Freeware][Freeware Icon]
 - [mas](https://github.com/mas-cli/mas) - A CLI for the Mac App Store. [![Open-Source Software][OSS Icon]](https://github.com/mas-cli/mas) ![Freeware][Freeware Icon]
+- [Painless Belt](https://github.com/shshemi/painless-belt) - Runs any command inside a macOS Seatbelt sandbox. [![Open-Source Software][OSS Icon]](https://github.com/shshemi/painless-belt) ![Freeware][Freeware Icon]
 - [quokka](https://github.com/dutradotdev/quokka) - Inspect and clean a USB-connected iPhone from the terminal. No jailbreak required. [![Open-Source Software][OSS Icon]](https://github.com/dutradotdev/quokka) ![Freeware][Freeware Icon]
 
 ## macOS Utilities


### PR DESCRIPTION
0. [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
1. [x] I confirm that I have read and understood the sections about "AI"-adjacent software
2. [x] Project URL: https://github.com/shshemi/painless-belt
3. [x] Why should this project be added: Painless Belt (`pb`) is a lightweight, open-source (MIT) CLI that wraps macOS's native Seatbelt API to run any command inside a configurable sandbox, scoping its filesystem and network access. It's a general-purpose macOS security/sandboxing utility — not an AI wrapper — comparable in spirit to `santa` in the Security list. Added under Command Line Utilities since it is a CLI tool.
4. [x] End all descriptions with a full stop/period
5. [x] Entry is ordered alphabetically
6. [x] Appropriate icon(s) added if applicable (OSS, freeware)