### PR TITLE
Add Walter

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@
 - [Telephone](http://www.64characters.com/telephone/) - A SIP softphone. Make phone calls over the Internet or your company’s network. [![Open-Source Software][OSS Icon]](https://github.com/eofster/Telephone) ![Freeware][Freeware Icon]
 - [TextExpander](https://smilesoftware.com/textexpander) - Create custom keyboard shortcuts for frequently-used text and pictures.
 - [Timing](https://timingapp.com/) - Automatic time and productivity tracking for Mac. Helps you stay on track with your work and ensures no billable hours get lost if you are billing hourly.
+- [Walter](https://walterlauncher.com) - Native, open-source launcher; a no-Electron Spotlight/Alfred/Raycast alternative configured in a TOML file. [![Open-Source Software][OSS Icon]](https://github.com/ekinertac/walter) ![Freeware][Freeware Icon]
 
 
 ### Sharing Files


### PR DESCRIPTION
Adds [Walter](https://walterlauncher.com) to the Productivity section.

Walter is a native, open-source (MIT) macOS launcher — a Spotlight/Alfred/Raycast alternative in pure Swift + AppKit (~4.3 MB, no Electron, no accounts, no telemetry), configured in a plain-text TOML file. Source: https://github.com/ekinertac/walter