### PR TITLE
Add Kaset to Video section

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,7 @@
 
 - [HandBrake](https://handbrake.fr/) - High performance video encoding and conversion tools with a nice GUI. [![Open-Source Software][OSS Icon]](https://github.com/HandBrake/HandBrake)
 - [IINA](https://lhc70000.github.io/iina/) - Media player with a minimalist design. [![Open-Source Software][OSS Icon]](https://github.com/lhc70000/iina) ![Freeware][Freeware Icon]
+- [Kaset](https://github.com/sozercan/kaset) - Native macOS client for YouTube Music and YouTube, built with Swift and SwiftUI. [![Open-Source Software][OSS Icon]](https://github.com/sozercan/kaset) ![Freeware][Freeware Icon]
 - [mpv](https://mpv.io/) - Media player. [![Open-Source Software][OSS Icon]](https://github.com/mpv-player/mpv)
 - [ScreenFlow](http://www.telestream.net/screenflow/) - Screencasting and video editing software.
 - [Subler](https://bitbucket.org/galad87/subler/wiki/Home) - Mux and tag MP4 files. [![Open-Source Software][OSS Icon]](https://bitbucket.org/galad87/subler/wiki/Home) ![Freeware][Freeware Icon]


### PR DESCRIPTION
Adds [Kaset](https://github.com/sozercan/kaset) to the **Video** section.

Kaset is a native macOS client for **YouTube Music and YouTube**, built with Swift and SwiftUI (MIT, actively maintained). Alongside YouTube Music playback, it now offers a full native YouTube video experience — browsing, search, subscriptions, Shorts, comments, and video playback with native controls, captions, quality selection, and picture in picture.

Inserted alphabetically between IINA and mpv, with the standard Open-Source + Freeware icons.