### PR TITLE
Add Krust Kubernetes dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@
 - [Integrity](http://peacockmedia.software/mac/integrity/free.html) - Easily find your website's broken links. ![Freeware][Freeware Icon]
 - [Kaleidoscope](http://www.kaleidoscopeapp.com/) - Powerful diff and merge application supporting text, images, and folders.
 - [Knuff](https://github.com/KnuffApp/Knuff) - The debug application for Apple Push Notification Service (APNs). [![Open-Source Software][OSS Icon]](https://github.com/KnuffApp/Knuff) ![Freeware][Freeware Icon]
+- [Krust](https://krust.io/) - Native Kubernetes dashboard for cluster resources, logs, YAML, Helm, topology, and port forwarding.
 - [Medis](https://getmedis.com) - A modern GUI for Redis.
 - [Pasteboard Viewer](https://apps.apple.com/app/id1499215709) - Inspect the system pasteboards. [![Open-Source Software][OSS Icon]](https://github.com/sindresorhus/Pasteboard-Viewer) ![Freeware][Freeware Icon]
 - [Paw](https://luckymarmot.com/paw) - The ultimate REST client.


### PR DESCRIPTION
0. [x] I have read the Contribution Guidelines
1. [x] I confirm that I have read and understood the sections about "AI"-adjacent software
2. [x] Project URL: https://krust.io/
3. [x] Why should this project be added: Krust is a native macOS Kubernetes dashboard for developers and DevOps engineers who manage Kubernetes clusters from a Mac. It is not an Electron app, and the list already includes developer-focused native macOS tools.
4. [x] End all descriptions with a full stop/period
5. [x] Entry is ordered alphabetically
6. [x] Appropriate icon(s) added if applicable (OSS, freeware)

Notes:
- I did not add OSS or Freeware icons because Krust is not fully open-source/freeware.
- The entry avoids AI-focused wording; Krust is listed here as a native Kubernetes dashboard/developer tool.