### PR TITLE
Add GitBench to Developers list

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@
 - [DevUtils](https://devutils.com) - All-in-one toolbox for developers. 42+ beautifully crafted useful developer tools, native macOS app, work offline.
 - [Gas Mask](https://github.com/2ndalpha/gasmask) - A simple hosts file manager which allows editing of host files and switching between them. [![Open-Source Software][OSS Icon]](https://github.com/2ndalpha/gasmask) ![Freeware][Freeware Icon]
 - [gitbar](https://github.com/Shikkic/gitbar) - Open source github contribution stats on your Menu Bar. [![Open-Source Software][OSS Icon]](https://github.com/Shikkic/gitbar) ![Freeware][Freeware Icon]
+- [GitBench](https://gitbench.builtbyzee.com/) - A native, GPU-accelerated Git client for managing many repositories at once, with a visual commit graph, inline diffs, and worktree/stash/submodule support. [![Open-Source Software][OSS Icon]](https://github.com/Zeejfps/GitBench) ![Freeware][Freeware Icon]
 - [GitUp](http://gitup.co/) - A simple but powerful Git macOS app. [![Open-Source Software][OSS Icon]](https://github.com/git-up/GitUp) ![Freeware][Freeware Icon]
 - [GitX-dev](https://rowanj.github.io/gitx/) - A fork (variant) of GitX, maintained and enhanced with productivity oriented changes.  [![Open-Source Software][OSS Icon]](https://github.com/rowanj/gitx) ![Freeware][Freeware Icon]
 - [Hopper Dissassembler](https://www.hopperapp.com) - A Dissassembler for MacOS and Linux. Has a Demo option for 30 minutes of productivity.


### PR DESCRIPTION
Adds **GitBench** to the list.

GitBench is a free, open-source (MIT) desktop Git client focused on working across many repositories at once: every repo is grouped in one sidebar for instant switching, with a visual commit graph, inline diffs, branch management, and worktree/stash/submodule support. Native, GPU-accelerated builds for Windows, macOS, and Linux.

- Website: https://gitbench.builtbyzee.com/
- Source: https://github.com/Zeejfps/GitBench