### PR TITLE
Add Pesty to Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@
 - [Pandan](https://apps.apple.com/app/id1569600264) - Time awareness in your menu bar. ![Freeware][Freeware Icon]
 - [Paste](http://pasteapp.me) - The new way to copy & paste for Mac.
 - [PDF Archiver](https://github.com/JulianKahnert/PDF-Archiver) - A nice tool for tagging and archiving tasks. [![Open-Source Software][OSS Icon]](https://github.com/JulianKahnert/PDF-Archiver)
+- [Pesty](https://www.moamenbasel.com/pesty/) - A native clipboard manager with a slide-up color-coded clipboard strip, pinboards, instant search, and keyboard-driven pasting. [![Open-Source Software][OSS Icon]](https://github.com/momenbasel/pesty)
 - [PopClip](http://pilotmoon.com/popclip/) - Instantly copy & paste, access actions like search, spelling, dictionary and more.
 - [Presentify](https://presentify.compzets.com) - Annotate anything on screen, be it, images, pdfs, videos, code, etc.
 - [Qbserve](https://qotoqot.com/qbserve/) - Automatic time and project tracking, timesheets, invoicing, and real-time productivity feedback.


### PR DESCRIPTION
**Category:** Applications > Productivity

**What it is:** Pesty is a free, open-source, native SwiftUI clipboard manager for macOS. It gives you a slide-up, color-coded clipboard strip with pinboards, instant search, and fully keyboard-driven pasting - a fast, native alternative to Paste.

**Why it belongs here:** It sits naturally alongside the existing clipboard tools in this list (Paste, ClipMenu, PopClip, ClipboardCleaner). It is open-source (MIT), so it carries the OSS symbol linking to source, and it is freely installable at no cost via Homebrew (`brew install --cask momenbasel/pesty/pesty`), so it also carries the Freeware symbol. Not Electron - it is a pure SwiftUI/AppKit app with zero third-party dependencies. Universal binary, Developer ID signed and Apple-notarized.

**Checklist:**
- [x] Searched existing entries - not a duplicate.
- [x] Single suggestion in this PR.
- [x] Title capitalized; description is short and ends with a period.
- [x] Inserted alphabetically (after PDF Archiver, before PopClip).
- [x] Primary link points to the app website; OSS symbol links to the source repo.
- [x] Not an Electron app; not an AI/LLM wrapper.
- [x] No tracking/referrer query strings in the URLs.