### PR TITLE
Add Raccoon to Security

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,6 +453,7 @@ Ansible playbook to configure a development and desktop environment from a clean
 * [OS-X-Security-and-Privacy-Guide](https://github.com/drduh/OS-X-Security-and-Privacy-Guide) [![Open-Source Software][OSS Icon]](https://github.com/drduh/OS-X-Security-and-Privacy-Guide)
 * [OSXCollector](https://github.com/Yelp/osxcollector) - Forensic evidence collection & analysis toolkit. [![Open-Source Software][OSS Icon]](https://github.com/Yelp/osxcollector) ![Freeware][Freeware Icon]
 * [Pareto Security](https://paretosecurity.app/) - A MenuBar app to automatically audit your Mac for basic security hygiene. [![Open-Source Software][OSS Icon]](https://github.com/paretoSecurity/pareto-mac/)
+* [Raccoon](https://github.com/thousandflowers/Raccoon) - CLI to audit Mac security, system info and manage an SSH fleet of Macs from one machine. [![Open-Source Software][OSS Icon]](https://github.com/thousandflowers/Raccoon)
 * [santa](https://github.com/google/santa) - A binary whitelisting/blacklisting system. [![Open-Source Software][OSS Icon]](https://github.com/google/santa) ![Freeware][Freeware Icon]
 * [Shimo](https://www.shimovpn.com) - Fully-featured VPN client for Mac.
 * [SimpleumSafe](https://simpleum.com/) - Encrypt, organize and sync files with macOS or iOS.


### PR DESCRIPTION
Adds Raccoon, a macOS companion toolkit: security audits with reversible --fix, system info, and SSH fleet management that audits many Macs in parallel with no agent on the remote hosts.

- Open source (MIT), ~1500 lines of shellcheck-clean Bash + bats test suite
- Runs on system Bash (3.2+), zero dependencies beyond macOS + git
- Repo: https://github.com/thousandflowers/Raccoon

Entry placed in Security, alphabetical order respected (after Pareto Security). Followed the contributing guidelines.