### PR TITLE
Add VoxFlow

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@
 - [Telephone](http://www.64characters.com/telephone/) - A SIP softphone. Make phone calls over the Internet or your company’s network. [![Open-Source Software][OSS Icon]](https://github.com/eofster/Telephone) ![Freeware][Freeware Icon]
 - [TextExpander](https://smilesoftware.com/textexpander) - Create custom keyboard shortcuts for frequently-used text and pictures.
 - [Timing](https://timingapp.com/) - Automatic time and productivity tracking for Mac. Helps you stay on track with your work and ensures no billable hours get lost if you are billing hourly.
+- [VoxFlow](https://xingbofeng.github.io/VoxFlow/) - Press-to-talk voice input that inserts transcripts into the focused app. [![Open-Source Software][OSS Icon]](https://github.com/xingbofeng/VoxFlow) ![Freeware][Freeware Icon]
 
 
 ### Sharing Files


### PR DESCRIPTION
0. [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
1. [x] I confirm that I have read and understood the sections about "AI"-adjacent software
2. [x] Project URL: https://xingbofeng.github.io/VoxFlow/
3. [x] Why should this project be added: VoxFlow is an open-source press-to-talk voice input app for macOS. It focuses on inserting transcripts into the currently focused app rather than being an AI prompt wrapper or chatbot interface.
4. [x] End all descriptions with a full stop/period
5. [x] Entry is ordered alphabetically
6. [x] Appropriate icon(s) added if applicable (OSS, freeware)

Repository: https://github.com/xingbofeng/VoxFlow
Latest release: https://github.com/xingbofeng/VoxFlow/releases/tag/v1.8.2
