### PR TITLE
Add Blurt to Audio

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@
 - [Audio Hijack](http://www.rogueamoeba.com/audiohijack/) - Record audio from any application like iTunes, Skype or Safari, or from hardware devices like microphones and mixers.
 - [Audio Profile Manager](https://apps.apple.com/us/app/audio-profile-manager/id1484150558?ls=1&mt=12) - Allows you to pin input/output devices for each particular combination of connected devices. May suppress HDMI displays from being chosen.
 - [BackgroundMusic](https://github.com/kyleneideck/BackgroundMusic) - Record system audio, control audio levels for individual apps, and automatically pauses your music player when other audio starts playing and unpauses it afterwards. [![Open-Source Software][OSS Icon]](https://github.com/kyleneideck/BackgroundMusic) ![Freeware][Freeware Icon]
+- [Blurt](https://blurtblurt.com) - Hold a hotkey, speak, and cleaned-up text is pasted into the focused app, powered by AssemblyAI cloud speech-to-text. [![Open-Source Software][OSS Icon]](https://github.com/alexkroman/blurt) ![Freeware][Freeware Icon]
 - [Fader](https://fader.pantafive.dev) - Menu bar volume mixer with per-app volume, one-click audio output switching, and Bluetooth headphone control. [![Open-Source Software][OSS Icon]](https://github.com/pantafive/fader) ![Freeware][Freeware Icon]
 - [krisp](https://krisp.ai/) - AI-powered app that removes background noise and echo from meetings leaving only human voice.
 - [Murmur](https://murmurtts.com/) - On-device text-to-speech studio with 860+ voices, voice cloning, and four AI models running entirely on Apple Silicon via MLX.


### PR DESCRIPTION
Adds [Blurt](https://blurtblurt.com) to the **Audio** section (alphabetically, after BackgroundMusic).

Blurt is an open-source (MIT), native Swift macOS dictation app: hold a hotkey, speak, and cleaned-up text is pasted into the focused app. It's powered by AssemblyAI's cloud speech-to-text (bring your own key, free tier).

Matches the entry format — single line with the `[![Open-Source Software][OSS Icon]](repo)` and `![Freeware][Freeware Icon]` labels (it's both open source and free).

- Repo: https://github.com/alexkroman/blurt