### PR TITLE
Add Awake to Menu Bar Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@
 - [APNGb](https://github.com/mancunianetz/APNGb) - .apng image assembler/disassembler app. [![Open-Source Software][OSS Icon]](https://github.com/mancunianetz/APNGb) ![Freeware][Freeware Icon]
 - [AppCleaner](http://freemacsoft.net/appcleaner/) - Uninstall your apps easily. ![Freeware][Freeware Icon]
 - [Artify](https://github.com/NghiaTranUIT/artify-macos) - A macOS X application for bringing dedicatedly 18th century Arts to everyone. [![Open-Source Software][OSS Icon]](https://github.com/NghiaTranUIT/artify-macos) ![Freeware][Freeware Icon]
+- [Awake](https://github.com/pistachionet/awake) - Menu bar app to keep your Mac awake with the lid closed. Useful for running agents, SSH sessions, downloads, and background tasks. [![Open-Source Software][OSS Icon]](https://github.com/pistachionet/awake) ![Freeware][Freeware Icon]
 - [Bartender](https://www.macbartender.com/) - Organize your menu bar apps.
 - [Batch Image Resizer](http://www.ironstarmedia.co.uk/resources/osx-image-resizer/) - Resize a large number of images quickly on your computer. ![Freeware][Freeware Icon]
 - [BeardedSpice](https://github.com/beardedspice/beardedspice) - Control web based media players with the media keys found on Mac keyboards. [![Open-Source Software][OSS Icon]](https://github.com/beardedspice/beardedspice) ![Freeware][Freeware Icon]


### PR DESCRIPTION
Adds Awake (https://github.com/pistachionet/awake), a free open-source 
menu bar app that keeps a MacBook awake with the lid closed via pmset 
disablesleep — the only mechanism that survives a lid close (caffeinate 
and IOKit assertions do not).

- Free and open source (MIT)
- macOS 13+, universal (Apple Silicon + Intel)
- Signed and notarized
- Homebrew tap: brew install --cask pistachionet/awake/awake