### PR TITLE
Add Orca

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@
 - [Kaleidoscope](http://www.kaleidoscopeapp.com/) - Powerful diff and merge application supporting text, images, and folders.
 - [Knuff](https://github.com/KnuffApp/Knuff) - The debug application for Apple Push Notification Service (APNs). [![Open-Source Software][OSS Icon]](https://github.com/KnuffApp/Knuff) ![Freeware][Freeware Icon]
 - [Medis](https://getmedis.com) - A modern GUI for Redis.
+- [Orca](https://onorca.dev) - An open-source IDE for running parallel AI coding agents (Claude Code, Codex, Cursor, Gemini, OpenCode), each in its own isolated git worktree. [![Open-Source Software][OSS Icon]](https://github.com/stablyai/orca) ![Freeware][Freeware Icon]
 - [Pasteboard Viewer](https://apps.apple.com/app/id1499215709) - Inspect the system pasteboards. [![Open-Source Software][OSS Icon]](https://github.com/sindresorhus/Pasteboard-Viewer) ![Freeware][Freeware Icon]
 - [Paw](https://luckymarmot.com/paw) - The ultimate REST client.
 - [pgMagic](https://pgmagic.app) - A PostgreSQL client that lets you talk to your database in SQL or natural language.


### PR DESCRIPTION
Adds **Orca** to the `Developers` section.

Orca is an open-source (MIT) macOS IDE/ADE (also Windows, Linux, and a mobile companion) for running a fleet of parallel AI coding agents — Claude Code, Codex, Cursor, Gemini, OpenCode and others — each in its own isolated git worktree, with a built-in terminal, source control, and SSH.

- Source: https://github.com/stablyai/orca
- Website: https://onorca.dev

Tagged Open-Source/Freeware (MIT), matching the existing entries. Thanks!