### PR TITLE
Add Drobu to Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@
 - [BetterTouchTool](https://folivora.ai) - Configure gestures for mouse and actions for keyboard shortcuts.
 - [ClipMenu](http://www.clipmenu.com/) - ClipBoard History Manager. [![Open-Source Software][OSS Icon]](https://github.com/naotaka/ClipMenu) ![Freeware][Freeware Icon]
 - [CloudClip](http://www.thinkbitz.com/cloudclip/) - Sync your clipboard between your Mac and your iOS devices. ![Freeware][Freeware Icon]
+- [Drobu](https://drobu.app) - A clipboard manager you can edit: capture text, images, GIFs, and screen recordings, then crop, trim, and paste them. Local-only, one-time purchase.
 - [Dropzone](https://aptonic.com/) - Create a popup grid of customizable actions that enhance productivity on your Mac.
 - [f.lux](https://justgetflux.com/) - Automatically adjust your computer screen to match lighting. ![Freeware][Freeware Icon]
 - [Fantastical](https://flexibits.com/fantastical) - Complete Calendar app replacement which uses natural language for creating events.


### PR DESCRIPTION
Adds **Drobu** to the Productivity section.

[Drobu](https://drobu.app) is a native macOS clipboard manager you can edit: it captures text, images, GIFs, and screen recordings into one searchable history, lets you crop, trim, and clean them in place, and pastes one item or many with a keystroke. Local-only, no account, one-time purchase.

Guidelines:
- Inserted alphabetically within Productivity (between CloudClip and Dropzone).
- Native Swift/AppKit app, not Electron.
- Paid, closed-source, and not on the App Store, so no Freeware/OSS badge (consistent with other paid entries like Alfred and Fantastical).