### PR TITLE
Add Nod under Audio

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@
 - [Fader](https://fader.pantafive.dev) - Menu bar volume mixer with per-app volume, one-click audio output switching, and Bluetooth headphone control. [![Open-Source Software][OSS Icon]](https://github.com/pantafive/fader) ![Freeware][Freeware Icon]
 - [krisp](https://krisp.ai/) - AI-powered app that removes background noise and echo from meetings leaving only human voice.
 - [Murmur](https://murmurtts.com/) - On-device text-to-speech studio with 860+ voices, voice cloning, and four AI models running entirely on Apple Silicon via MLX.
+- [Nod](https://hellonod.app/) - Automatically records, transcribes and summarizes meetings, calls and voice notes across Zoom, Meet, Teams and more, in 13 languages.
 - [Plug](https://plugformac.com) - Discover and listen to music from Hype Machine. [![Open-Source Software][OSS Icon]](https://github.com/wulkano/Plug) ![Freeware][Freeware Icon]
 - [Recordia](https://sindresorhus.com/recordia) - Record audio directly from the menu bar or with a global keyboard shortcut.
 - [VOX Player](https://coppertino.com/vox/mac) - Play numerous lossy and lossless audio formats.


### PR DESCRIPTION
0. [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
1. [x] I confirm that I have read and understood the sections about "AI"-adjacent software
2. [x] Project URL: https://hellonod.app/
3. [x] Why should this project be added: Nod is a native macOS (Swift) app whose core purpose is to record, transcribe and summarize meetings, calls and voice notes locally across 22+ tools (Zoom, Meet, Teams, etc.) — it is a meeting recorder/transcriber, not an LLM chat wrapper; transcription uses specialised speech models as part of that larger process. It is a paid app with a 14-day free trial for maintainers to validate. Privacy-first: audio is never stored, data is kept in the EU, no model training on user data. Not Electron.
4. [x] End all descriptions with a full stop/period
5. [x] Entry is ordered alphabetically (Audio section, between Murmur and Plug)
6. [x] Appropriate icon(s) added if applicable (paid app, so no OSS/freeware icon)