### PR TITLE
Add Mole Widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,7 @@
 - [Media Converter](http://media-converter.sourceforge.net/) - Simple (drag and drop) but advanced media conversion. [![Open-Source Software][OSS Icon]](https://sourceforge.net/p/media-converter/code/ci/master/tree/) ![Freeware][Freeware Icon]
 - [Menubar Colors](https://github.com/nvzqz/Menubar-Colors) - Convenient access to the system color panel. [![Open-Source Software][OSS Icon]](https://github.com/nvzqz/Menubar-Colors) ![Freeware][Freeware Icon]
 - [MenuMeters](http://member.ipmu.jp/yuji.tachikawa/MenuMetersElCapitan/) - A set of CPU, memory, disk, and network monitoring tools for macOS. [![Open-Source Software][OSS Icon]](https://github.com/yujitach/MenuMeters)
+- [Mole Widget](https://github.com/bsnkhua/mole-widget) - Lightweight system monitor for the menu bar with live CPU, memory, disk, network, battery, and process metrics. [![Open-Source Software][OSS Icon]](https://github.com/bsnkhua/mole-widget) ![Freeware][Freeware Icon]
 - [MonitorControl](https://github.com/MonitorControl/MonitorControl) - Control your display's brightness and volume on your Mac as if it was a native Apple Display. Use Apple Keyboard keys or custom shortcuts. Shows the native macOS OSDs. [![Open-Source Software][OSS Icon]](https://github.com/MonitorControl/MonitorControl)
 - [Monodraw](http://monodraw.helftone.com/) - A powerful ASCII art editor.
 - [Mounty](http://enjoygineering.com/mounty/) - A tiny tool to re-mount write-protected NTFS volumes under macOS 10.9+ in read-write mode.


### PR DESCRIPTION
Adds **Mole Widget** to the Utilities section.

- **Repo:** https://github.com/bsnkhua/mole-widget
- Open-source (MIT), native Swift menu bar app
- Lightweight system monitor: live CPU, memory, disk, network, battery, and process metrics
- Entry placed alphabetically between MenuMeters and MonitorControl, with OSS + Freeware badges matching the list style