### PR TITLE
Add AI Usage Ball

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@
 ### Utilities
 
 - [1Password](https://1password.com) - Password Manager and Secure Wallet.
+- [AI Usage Ball](https://aiusageball.com) - Menu bar gauges for Claude, Codex, and Antigravity usage limits.
 - [AnyBar](https://github.com/tonsky/AnyBar) - A menubar status indicator. [![Open-Source Software][OSS Icon]](https://github.com/tonsky/AnyBar) ![Freeware][Freeware Icon]
 - [APNGb](https://github.com/mancunianetz/APNGb) - .apng image assembler/disassembler app. [![Open-Source Software][OSS Icon]](https://github.com/mancunianetz/APNGb) ![Freeware][Freeware Icon]
 - [AppCleaner](http://freemacsoft.net/appcleaner/) - Uninstall your apps easily. ![Freeware][Freeware Icon]


### PR DESCRIPTION
<!-- Thanks for contributing to awesome-macOS  -->

<!-- Please fill out the following: -->

0. [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
1. [x] I confirm that I have read and understood the sections about "AI"-adjacent software
2. [x] Project URL: https://aiusageball.com
3. [x] Why should this project be added: AI Usage Ball is a macOS menu bar/status utility that keeps Claude, Codex, and Antigravity usage limits visible. It is not a prompt wrapper or generative AI interface; it is a local usage monitor for developers.
4. [x] End all descriptions with a full stop/period
5. [x] Entry is ordered alphabetically
6. [x] Appropriate icon(s) added if applicable (OSS, freeware)

Additional context: the signed app has a 30-day free trial, and the source is available for auditability at https://github.com/aiusageball/ai-usage-ball.
