### PR TITLE
Add Bosun to Developers

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@
 
 - [Anvil](http://anvilformac.com/) - Serve up static sites and Rack apps with simple URLs and zero configuration. ![Freeware][Freeware Icon]
 - [Base 2](http://menial.co.uk/base/) - A GUI for managing SQLite databases.
+- [Bosun](https://bosun.dev) - Menu bar app that shows every open port, tunnel, VPN connection, and Docker container mapped to its process.
 - [CocoaRestClient](https://mmattozzi.github.io/cocoa-rest-client) - An app for testing REST endpoints. [![Open-Source Software][OSS Icon]](https://github.com/mmattozzi/cocoa-rest-client) ![Freeware][Freeware Icon]
 - [Cork](https://corkmac.app) - A fast, intuitive Homebrew GUI [![Open-Source Software][OSS Icon]](https://github.com/buresdv/Cork)
 - [Dash](https://kapeli.com/dash) - An API Documentation Browser and Code Snippet Manager.


### PR DESCRIPTION
Bosun is a native macOS menu bar app that shows every open port, tunnel (ngrok/Cloudflare), VPN connection, and Docker container mapped to its process, with one-click kill.

Commercial app with a genuine 14-day free trial available directly (not bundled via SetApp) — bosun.dev.