### PR TITLE
Add MoonProxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,7 @@
 - [MonitorControl](https://github.com/MonitorControl/MonitorControl) - Control your display's brightness and volume on your Mac as if it was a native Apple Display. Use Apple Keyboard keys or custom shortcuts. Shows the native macOS OSDs. [![Open-Source Software][OSS Icon]](https://github.com/MonitorControl/MonitorControl)
 - [Monodraw](http://monodraw.helftone.com/) - A powerful ASCII art editor.
 - [Mounty](http://enjoygineering.com/mounty/) - A tiny tool to re-mount write-protected NTFS volumes under macOS 10.9+ in read-write mode.
+- [MoonProxy](https://moonproxy.app) - A cross-platform desktop GUI client for FRP (fast reverse proxy), making intranet penetration and NAT traversal accessible to non-technical users. [![Open-Source Software][OSS Icon]](https://github.com/MoonProxyHQ/moonproxy-desktop) ![Freeware][Freeware Icon]
 - [Noizio](http://noiz.io/) - Ambient sound equalizer for relaxation or productivity.
 - [Notational Velocity](http://notational.net/) - Store, retrieve and sync notes within a minimal GUI. [![Open-Source Software][OSS Icon]](https://github.com/scrod/nv/) ![Freeware][Freeware Icon]
 - [Noti](https://noti.center/) - Receive Android notifications on your mac (with PushBullet). [![Open-Source Software][OSS Icon]](https://github.com/jariz/Noti/) ![Freeware][Freeware Icon]


### PR DESCRIPTION
## What
Adds [MoonProxy](https://moonproxy.app) to the `### Utilities` section, ordered alphabetically between `Mounty` and `Noizio`.

## Why
MoonProxy is a cross-platform desktop GUI client for [FRP](https://github.com/fatedier/frp) (fast reverse proxy). It makes intranet penetration and NAT traversal accessible to non-technical users, bundling the `frpc` binary via the Tauri sidecar mechanism so no separate install is needed.

It fits the spirit of this list:
- Built with **Tauri v2 + Vue 3 + Rust** — native, not Electron. ✅
- MIT licensed and free (as in free beer). ✅
- Supports macOS (and Windows). ✅
- Not an AI prompt wrapper / LLM interface. ✅

It complements existing networking utilities in this section such as `SSH Tunnel`, `Loading`, `Little Snitch`, and `Radio Silence`.

## Project
- Website: https://moonproxy.app
- Source: https://github.com/MoonProxyHQ/moonproxy-desktop

## Checklist
- [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
- [x] Not an Electron app (built with Tauri v2)
- [x] Not an AI prompt wrapper / LLM interface
- [x] Primary link points to the application website; OSS icon links to the source code
- [x] Freeware icon added (the app is free)
- [x] Description ends with a full stop/period
- [x] Entry is ordered alphabetically (placed between `Mounty` and `Noizio`)
- [x] No trailing whitespace; no referrer/tracking query strings
- [x] Not a duplicate (searched existing entries)