### PR TITLE
Remove Juicy due to excessive telemetry collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,7 +296,6 @@
 - [Itsytv](https://itsytv.app) - Control your Apple TV from the menu bar with remote, now playing widget, and app launcher. [![Open-Source Software][OSS Icon]](https://github.com/nickustinov/itsytv-macos) ![Freeware][Freeware Icon]
 - [iStat Menus](https://bjango.com/mac/istatmenus/) - An advanced system monitor for your menubar.
 - [Jiffy](https://sindresorhus.com/jiffy) - Discover and share the best GIFs on GIPHY. ![Freeware][Freeware Icon]
-- [Juicy](https://getjuicy.app) - Custom battery alerts and battery health monitoring your Mac.
 - [Kawa](https://github.com/noraesae/kawa) - A better input source switcher with shortcuts. [![Open-Source Software][OSS Icon]](https://github.com/noraesae/kawa) ![Freeware][Freeware Icon]
 - [KeepingYouAwake](https://github.com/newmarcel/KeepingYouAwake) - Menu bar utility that prevents Mac from going to sleep. [![Open-Source Software][OSS Icon]](https://github.com/newmarcel/KeepingYouAwake) ![Freeware][Freeware Icon]
 - [Keka](https://www.keka.io/) - Compress to and extract from many archive file formats. ![Freeware][Freeware Icon]


### PR DESCRIPTION
The application aggressively attempts to collect telemetry data via TelemetryDeck.

My Pihole registers upwards of 5k connection attempts per 24h window.

<img width="473" height="93" alt="Screenshot 2026-07-05 at 07 57 41" src="https://github.com/user-attachments/assets/0dedde4c-363d-4f68-b6bc-58cd0174154d" />

This only started showing up after I had installed the app. I had asked the author @rylax via email for a comment, to no avail. Looking into it myself, I verified that Juicy is the only application on my computer using TelemetryDeck.

<img width="1100" height="198" alt="Screenshot 2026-07-05 at 07 56 22" src="https://github.com/user-attachments/assets/84879105-5e12-4aad-a1b6-e345880683cb" />

While Juicy's functionality is nice, forcing non-optional telemetry collection on users, especially this aggressive, disqualifies any application for me. Therefore, I propose removing Juicy until and unless this is rectified.