### PR TITLE
Add Settle

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,6 +360,7 @@
 - [Phoenix](https://github.com/kasper/phoenix) - A lightweight window and app manager scriptable with JavaScript. [![Open-Source Software][OSS Icon]](https://github.com/Hammerspoon/hammerspoon) ![Freeware][Freeware Icon]
 - [Rectangle](https://rectangleapp.com/) - Easily organize windows without using a mouse. [![Open-Source Software][OSS Icon]](https://github.com/rxhanson/Rectangle) ![Freeware][Freeware Icon]
 - [ShiftPlus](https://shiftplus.app/) - macOS workspace manager to switch workspaces, restore apps and windows across Spaces, monitors, and Macs in one click.
+- [Settle](https://settle.gokhangokova.com/) - Saves window layouts and switches them automatically on monitor, time, or app launch. `Paid`
 - [Stay](https://cordlessdog.com/stay/) - Resize/position windows when displays change.
 - [Swish](https://highlyopinionated.co/swish/) - Control windows and applications with trackpad gestures.
 - [yabai](https://github.com/koekeishiya/yabai) - Tiling window manager with focus follows mouse. [![Open-Source Software][OSS Icon]](https://github.com/koekeishiya/yabai) ![Freeware][Freeware Icon]


### PR DESCRIPTION
Adds Settle to Window Management. Native macOS (Swift) window manager that saves window layouts and switches them automatically on monitor connect/disconnect, time of day, or app launch. Paid ($9.99 one-time, 7-day trial), closed-source, notarized DMG. Homepage: https://settle.gokhangokova.com/

<!-- Thanks for contributing to awesome-macOS  -->

<!-- Please fill out the following: -->

0. [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
1. [x] I confirm that I have read and understood the sections about "AI"-adjacent software
2. [x] Project URL:
3. [x] Why should this project be added:
4. [x] End all descriptions with a full stop/period
5. [x] Entry is ordered alphabetically
6. [x] Appropriate icon(s) added if applicable (OSS, freeware)

<!--

Again, please read https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md if you didn't yet.
If you don't fill out this template or replace it wholesale, your pull request will be closed without discussion.

-->
