### PR TITLE
Add Sundown

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@
 - [Rocket](http://matthewpalmer.net/rocket/) - Makes typing emoji faster and easier using Slack-style shortcuts. ![Freeware][Freeware Icon]
 - [ScreenTranslate](https://screentranslate.filient.ai/) - Capture any area or select text to translate instantly, fully on-device. [![Open-Source Software][OSS Icon]](https://github.com/hcmhcs/screenTranslate) ![Freeware][Freeware Icon]
 - [SelfControl](https://selfcontrolapp.com/) - Block access to distracting websites. [![Open-Source Software][OSS Icon]](https://github.com/SelfControlApp/selfcontrol/) ![Freeware][Freeware Icon]
+- [Sundown](https://trysundown.com/) - Deep blue light filter and display health app for Mac with flicker-free mode.
 - [Simplenote](https://simplenote.com/) - Simple cross-platform note taking app with cloud-based syncing. ![Freeware][Freeware Icon]
 - [Taskade](https://apps.apple.com/us/app/taskade-manage-anything/id1490048917/) - Real-time organization and task management tool.
 - [TaskPaper](https://www.taskpaper.com/) - Plain text to-do lists.


### PR DESCRIPTION
## App Details

- **App name:** Sundown
- **App URL:** https://trysundown.com/
- **Category:** Productivity (alongside f.lux)
- **Description:** Deep blue light filter and display health app for Mac with flicker-free mode.
- **Free trial:** Yes — 7-day free trial
- **Platform:** macOS only (native Swift, 398KB)
- **Not Electron:** Correct — 100% native Swift/AppKit

## What It Does

Sundown is a Mac menu bar app for display warmth and eye comfort. It filters blue light down to 500K color temperature (deeper than Night Shift or f.lux) and includes a flicker-free mode that eliminates PWM strobing on miniLED MacBook Pros — a hardware-level backlight issue that causes headaches at low brightness.

## Placement

Added alphabetically in the Productivity section between SelfControl and Simplenote, in the same category as f.lux (display/eye comfort).