### PR TITLE
Add PointFlow to Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,7 @@
 - [OnyX](http://www.titanium.free.fr/) -  Multifunction utility to verify disks and files, run cleaning and system maintenance tasks, configure hidden options and more. ![Freeware][Freeware Icon]
 - [Paparazzi](http://derailer.org/paparazzi/) - A small utility that makes screenshots of webpages. ![Freeware][Freeware Icon]
 - [Paragon NTFS](http://www.paragon-drivers.com/ntfs-mac/) - World fastest NTFS driver.
+- [PointFlow](https://github.com/supreeth-Finsamudra/pointflow) - Use a phone as the Mac's trackpad, keyboard, and terminal; view and type into tmux panes from the phone browser. [![Open-Source Software][OSS Icon]](https://github.com/supreeth-Finsamudra/pointflow) ![Freeware][Freeware Icon]
 - [PureMac](https://github.com/momenbasel/PureMac) - Free and open-source macOS cleaner that removes system caches, Xcode junk, Homebrew cache, and more with no telemetry or network calls. [![Open-Source Software][OSS Icon]](https://github.com/momenbasel/PureMac) ![Freeware][Freeware Icon]
 - [Radio Silence](https://radiosilenceapp.com) - Simple to use firewall and network monitor.
 - [Microsoft Remote Desktop Connection Client](https://itunes.apple.com/us/app/microsoft-remote-desktop/id715768417) - Remote Desktop Connection Client lets you connect from your Macintosh computer to a Windows-based computer.


### PR DESCRIPTION
Adds [PointFlow](https://github.com/supreeth-Finsamudra/pointflow) — a single ~4 MB Rust binary that turns a phone browser into the Mac's trackpad, keyboard, and terminal: full-color xterm.js views of tmux panes/Terminal.app tabs with type-back, plus lock-screen Approve/Deny push for Claude Code sessions. Token-paired via QR; optional Cloudflare quick tunnel. MIT, free.

Placed alphabetically in *Utilities* with the OSS/Freeware icons per the list format.

Disclosure: I'm one of the authors. Happy to adjust wording, category, or placement.