### PR TITLE
Add Markout (native macOS Markdown editor)

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,7 @@
 - [MacDown](http://macdown.uranusjr.com/) - Markdown editor. [![Open-Source Software][OSS Icon]](https://github.com/MacDownApp/macdown) ![Freeware][Freeware Icon]
 - [Mackup](https://github.com/lra/mackup) - Keep your application settings in sync. [![Open-Source Software][OSS Icon]](https://github.com/lra/mackup) ![Freeware][Freeware Icon]
 - [MacPass](https://macpass.github.io/) - Password Manager. [![Open-Source Software][OSS Icon]](https://github.com/MacPass/MacPass) ![Freeware][Freeware Icon]
+- [Markout](https://github.com/maxmilian/markout) - Native Markdown editor with live preview, math, and diagrams. [![Open-Source Software][OSS Icon]](https://github.com/maxmilian/markout) ![Freeware][Freeware Icon]
 - [Media Converter](http://media-converter.sourceforge.net/) - Simple (drag and drop) but advanced media conversion. [![Open-Source Software][OSS Icon]](https://sourceforge.net/p/media-converter/code/ci/master/tree/) ![Freeware][Freeware Icon]
 - [Menubar Colors](https://github.com/nvzqz/Menubar-Colors) - Convenient access to the system color panel. [![Open-Source Software][OSS Icon]](https://github.com/nvzqz/Menubar-Colors) ![Freeware][Freeware Icon]
 - [MenuMeters](http://member.ipmu.jp/yuji.tachikawa/MenuMetersElCapitan/) - A set of CPU, memory, disk, and network monitoring tools for macOS. [![Open-Source Software][OSS Icon]](https://github.com/yujitach/MenuMeters)


### PR DESCRIPTION
Adds **Markout** to the *Utilities* section (alphabetically after the Mac* entries).

[Markout](https://github.com/maxmilian/markout) is an MIT-licensed, native macOS Markdown editor for Apple Silicon — a spiritual successor to the unmaintained MacDown. Split live preview with math and diagrams, rendered offline, HTML/PDF export.

- Open source: https://github.com/maxmilian/markout (MIT)
- Free / Freeware

Badges match the existing entries (`OSS Icon` + `Freeware Icon`).