### PR TITLE
Add Clavio to Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@
 
 - [Alfred](https://www.alfredapp.com/) - Boosts your efficiency and productivity.
 - [BetterTouchTool](https://folivora.ai) - Configure gestures for mouse and actions for keyboard shortcuts.
+- [Clavio](https://clavioapp.com) - AI hands-free dictation that types clean text into any app, with per-app tone and optional auto-send. [`brew install --cask zhingel/clavio/clavio`]
 - [ClipMenu](http://www.clipmenu.com/) - ClipBoard History Manager. [![Open-Source Software][OSS Icon]](https://github.com/naotaka/ClipMenu) ![Freeware][Freeware Icon]
 - [CloudClip](http://www.thinkbitz.com/cloudclip/) - Sync your clipboard between your Mac and your iOS devices. ![Freeware][Freeware Icon]
 - [Dropzone](https://aptonic.com/) - Create a popup grid of customizable actions that enhance productivity on your Mac.


### PR DESCRIPTION
Adds Clavio to the Productivity section. An AI dictation app for macOS: speak in any app and clean, punctuated text types itself, with per-app tone and optional auto-send. Installs via a Homebrew cask (brew install --cask zhingel/clavio/clavio); notarized, macOS 14+. Free tier — https://clavioapp.com