### PR TITLE
Add Burrete to Finder

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@
 
 ### Finder
 
+- [Burrete](https://burrete-landing.vercel.app) - Preview molecular structures, trajectories, and chemistry tables in Finder Quick Look. [![Open-Source Software][OSS Icon]](https://github.com/SergeiNikolenko/Burrete) ![Freeware][Freeware Icon]
 - [ForkLift](https://itunes.apple.com/us/app/forklift-file-manager-ftp/id412448059) - File Manager and FTP/SFTP/WebDAV/Amazon S3 client.
 - [Path Finder](http://www.cocoatech.com/pathfinder/) - A powerful dual-pane browser alternative to Finder.
 - [Quicklook-Plugins](https://github.com/sindresorhus/quick-look-plugins) - List of extra quicklook plugins to enable previewing more filetypes in the Finder.


### PR DESCRIPTION
Adds Burrete to the Finder section. It is a free, open-source macOS molecular-file workspace and Quick Look extension for structures, trajectories, and chemistry tables.\n\nDisclosure: I am the author and maintainer of Burrete.