### PR TITLE
Add GuacSweep

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,6 +378,7 @@
 ## Command Line Utilities
 
 - [Awesome macOS Command Line](https://github.com/herrbischoff/awesome-osx-command-line) - Use your macOS terminal shell to do awesome things.
+- [GuacSweep](https://github.com/avocadoattack/GuacSweep) - Lean, safety-first, interactive CLI cleanup tool with zero dependencies, bash 3.2-compatible. [![Open-Source Software][OSS Icon]](https://github.com/avocadoattack/GuacSweep) ![Freeware][Freeware Icon]
 - [m-cli](https://github.com/rgcr/m-cli) -  Swiss Army Knife for macOS.
 - [Mac-CLI](https://github.com/guarinogabriel/Mac-CLI) -  macOS command line tools for developers.
 - [Mocker](https://github.com/us/mocker) - Docker-compatible container CLI for macOS, built on Apple's Containerization framework. [![Open-Source Software][OSS Icon]](https://github.com/us/mocker) ![Freeware][Freeware Icon]


### PR DESCRIPTION
- [x] I have read the Contribution Guidelines
- Project URL: https://github.com/avocadoattack/GuacSweep
- Why should this project be added: A lean, safety-first (no wholesale `rm`) macOS maintenance tool with zero third-party dependencies, written to be compatible with bash 3.2 (the version every Mac still ships with by default), so it runs out of the box with no setup. It replaces the common CleanMyMac-style workflow with plain, auditable bash covering cache cleanup, DNS flush, Time Machine snapshot thinning, and orphaned app-data detection.
- [x] End all descriptions with a full stop/period
- [x] Entry is ordered alphabetically
- [x] Appropriate icon(s) added if applicable (OSS, freeware)