### PR TITLE
Add gmacFTP to Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,7 @@
 - [ClipboardCleaner](https://github.com/Zuehlke/Clipboard_Cleaner) - Automatically removes text formatting from the clipboard. [![Open-Source Software][OSS Icon]](https://github.com/Zuehlke/Clipboard_Cleaner) ![Freeware][Freeware Icon]
 - [CommandQ](https://clickontyler.com/commandq/) - Never accidentally quit an app again.
 - [ControlPlane](http://www.controlplaneapp.com/) - Automate running tasks based on where you are or what you do. [![Open-Source Software][OSS Icon]](https://github.com/dustinrue/ControlPlane) ![Freeware][Freeware Icon]
+- [gmacFTP](https://github.com/GMAC-pl/gmacFTP) - A free, open-source dual-pane FTP/FTPS/SFTP client for macOS, built in Rust. [![Open-Source Software][OSS Icon]](https://github.com/GMAC-pl/gmacFTP) ![Freeware][Freeware Icon]
 - [DaisyDisk](https://daisydiskapp.com/) - Analyze disk usage and free up disk space.
 - [Deliveries](http://junecloud.com/software/mac/deliveries.html) - Beautiful and simple package tracking.
 - [DisableMonitor](https://github.com/Eun/DisableMonitor) - Easily disable or enable a monitor on your Mac. [![Open-Source Software][OSS Icon]](https://github.com/Eun/DisableMonitor) ![Freeware][Freeware Icon]


### PR DESCRIPTION
Adds [gmacFTP](https://github.com/GMAC-pl/gmacFTP) to the Utilities section.

- Free, open-source (GPL-3.0) dual-pane FTP/FTPS/SFTP client for macOS
- Built entirely in Rust with a Slint GPU-accelerated UI
- ~7.5 MB, signed and notarized
- No Electron, no webview, no telemetry

Placed alphabetically in the Utilities section.