### PR TITLE
Add Crest

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,7 @@
 - [ClipboardCleaner](https://github.com/Zuehlke/Clipboard_Cleaner) - Automatically removes text formatting from the clipboard. [![Open-Source Software][OSS Icon]](https://github.com/Zuehlke/Clipboard_Cleaner) ![Freeware][Freeware Icon]
 - [CommandQ](https://clickontyler.com/commandq/) - Never accidentally quit an app again.
 - [ControlPlane](http://www.controlplaneapp.com/) - Automate running tasks based on where you are or what you do. [![Open-Source Software][OSS Icon]](https://github.com/dustinrue/ControlPlane) ![Freeware][Freeware Icon]
+- [Crest](https://crestnotch.app) - Notch panel with media controls, calendar, todos, system stats, and a built-in Claude co-pilot.
 - [DaisyDisk](https://daisydiskapp.com/) - Analyze disk usage and free up disk space.
 - [Deliveries](http://junecloud.com/software/mac/deliveries.html) - Beautiful and simple package tracking.
 - [DisableMonitor](https://github.com/Eun/DisableMonitor) - Easily disable or enable a monitor on your Mac. [![Open-Source Software][OSS Icon]](https://github.com/Eun/DisableMonitor) ![Freeware][Freeware Icon]


### PR DESCRIPTION
0. [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
1. [x] I confirm that I have read and understood the sections about "AI"-adjacent software
2. [x] Project URL: https://crestnotch.app
3. [x] Why should this project be added: Crest turns the MacBook notch into a panel of small utilities: media controls, calendar, todos, clipboard history, a file shelf, and system stats, with three modes that decide what shows up when. It is a native SwiftUI/AppKit app (not Electron), signed and notarized, for macOS 14 and up. On the AI rule: the app's main purpose is the notch utility panel, not interfacing with LLMs; one of its modules is a Claude assistant, and I kept it in the description for transparency. If you feel that crosses the line I understand. It is commercial (free tier plus a one-time Pro unlock) and offers a 7-day full Pro trial with no card, so maintainers can validate everything. Disclosure: I am the developer.
4. [x] End all descriptions with a full stop/period
5. [x] Entry is ordered alphabetically
6. [x] Appropriate icon(s) added if applicable (OSS, freeware): none apply, Crest is closed source and charges for Pro, matching how Bartender and DaisyDisk are listed