### PR TITLE
Add SupaSidebar to Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@
 - [ScreenTranslate](https://screentranslate.filient.ai/) - Capture any area or select text to translate instantly, fully on-device. [![Open-Source Software][OSS Icon]](https://github.com/hcmhcs/screenTranslate) ![Freeware][Freeware Icon]
 - [SelfControl](https://selfcontrolapp.com/) - Block access to distracting websites. [![Open-Source Software][OSS Icon]](https://github.com/SelfControlApp/selfcontrol/) ![Freeware][Freeware Icon]
 - [Simplenote](https://simplenote.com/) - Simple cross-platform note taking app with cloud-based syncing. ![Freeware][Freeware Icon]
+- [SupaSidebar](https://supasidebar.com/) - One Mac sidebar for organizing tabs, bookmarks, files, and apps across all your browsers. ![Freeware][Freeware Icon]
 - [Taskade](https://apps.apple.com/us/app/taskade-manage-anything/id1490048917/) - Real-time organization and task management tool.
 - [TaskPaper](https://www.taskpaper.com/) - Plain text to-do lists.
 - [Telephone](http://www.64characters.com/telephone/) - A SIP softphone. Make phone calls over the Internet or your company’s network. [![Open-Source Software][OSS Icon]](https://github.com/eofster/Telephone) ![Freeware][Freeware Icon]


### PR DESCRIPTION
## What this adds

Adds SupaSidebar to the Productivity section (alphabetically, after Simplenote).

SupaSidebar is a native macOS app that brings an Arc-style sidebar to every browser - one place to organize tabs, bookmarks, files, and apps across all your browsers.

- Website: https://supasidebar.com/
- Install: brew install --cask supasidebar
- Native Swift / SwiftUI macOS app, free to start (Freeware badge)

## Checks

- [x] Searched the list for duplicates - not already present
- [x] Placed alphabetically within Productivity
- [x] One concise, factual sentence
- [x] Freeware badge only (no OSS, no App Store)

Disclosure: I'm the developer of SupaSidebar.