### PR TITLE
Add Deckle to Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,7 @@
 - [CommandQ](https://clickontyler.com/commandq/) - Never accidentally quit an app again.
 - [ControlPlane](http://www.controlplaneapp.com/) - Automate running tasks based on where you are or what you do. [![Open-Source Software][OSS Icon]](https://github.com/dustinrue/ControlPlane) ![Freeware][Freeware Icon]
 - [DaisyDisk](https://daisydiskapp.com/) - Analyze disk usage and free up disk space.
+- [Deckle](https://github.com/YellowFoxH4XOR/deckle) - Lay a subtle paper-grain texture over the whole screen; click-through, menu bar only. [![Open-Source Software][OSS Icon]](https://github.com/YellowFoxH4XOR/deckle) ![Freeware][Freeware Icon]
 - [Deliveries](http://junecloud.com/software/mac/deliveries.html) - Beautiful and simple package tracking.
 - [DisableMonitor](https://github.com/Eun/DisableMonitor) - Easily disable or enable a monitor on your Mac. [![Open-Source Software][OSS Icon]](https://github.com/Eun/DisableMonitor) ![Freeware][Freeware Icon]
 - [Dozer](https://github.com/Mortennn/Dozer) - Hide MacOS menubar items. [![Open-Source Software][OSS Icon]](https://github.com/Mortennn/Dozer) ![Freeware][Freeware Icon]


### PR DESCRIPTION
Adds [Deckle](https://github.com/YellowFoxH4XOR/deckle) — a free, open-source (MIT) menu bar app that lays a subtle procedural paper-grain texture over the whole screen so it feels less like backlit glass. Click-through, signed & notarized, universal binary.

Inserted alphabetically in **Utilities** with the OSS + Freeware badges per the list format.