### PR TITLE
Add Chat Session Managers

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@
 
 - [Anvil](http://anvilformac.com/) - Serve up static sites and Rack apps with simple URLs and zero configuration. ![Freeware][Freeware Icon]
 - [Base 2](http://menial.co.uk/base/) - A GUI for managing SQLite databases.
+- [Chat Session Managers](https://czxxxczx73-cell.github.io/chat-session-managers/) - Search, archive, restore, and safely delete local Codex, Claude Code, and Grok session history. [![Open-Source Software][OSS Icon]](https://github.com/czxxxczx73-cell/chat-session-managers) ![Freeware][Freeware Icon]
 - [CocoaRestClient](https://mmattozzi.github.io/cocoa-rest-client) - An app for testing REST endpoints. [![Open-Source Software][OSS Icon]](https://github.com/mmattozzi/cocoa-rest-client) ![Freeware][Freeware Icon]
 - [Cork](https://corkmac.app) - A fast, intuitive Homebrew GUI [![Open-Source Software][OSS Icon]](https://github.com/buresdv/Cork)
 - [Dash](https://kapeli.com/dash) - An API Documentation Browser and Code Snippet Manager.
@@ -207,8 +208,6 @@
 
 ### Productivity
 
-- [Chat Session Managers](https://github.com/czxxxczx73-cell/chat-session-managers) - Browse, search, archive, and delete local Codex, Claude Code, and Grok conversation history. [![Open-Source Software][OSS Icon]](https://github.com/czxxxczx73-cell/chat-session-managers) ![Freeware][Freeware Icon]
-- [Screenshot Home](https://github.com/czxxxczx73-cell/Screenshot-Home) - Private local-first screenshot library for macOS. [![Open-Source Software][OSS Icon]](https://github.com/czxxxczx73-cell/Screenshot-Home) ![Freeware][Freeware Icon]
 - [Alfred](https://www.alfredapp.com/) - Boosts your efficiency and productivity.
 - [BetterTouchTool](https://folivora.ai) - Configure gestures for mouse and actions for keyboard shortcuts.
 - [ClipMenu](http://www.clipmenu.com/) - ClipBoard History Manager. [![Open-Source Software][OSS Icon]](https://github.com/naotaka/ClipMenu) ![Freeware][Freeware Icon]

--- a/README.md
+++ b/README.md
@@ -207,6 +207,8 @@
 
 ### Productivity
 
+- [Chat Session Managers](https://github.com/czxxxczx73-cell/chat-session-managers) - Browse, search, archive, and delete local Codex, Claude Code, and Grok conversation history. [![Open-Source Software][OSS Icon]](https://github.com/czxxxczx73-cell/chat-session-managers) ![Freeware][Freeware Icon]
+- [Screenshot Home](https://github.com/czxxxczx73-cell/Screenshot-Home) - Private local-first screenshot library for macOS. [![Open-Source Software][OSS Icon]](https://github.com/czxxxczx73-cell/Screenshot-Home) ![Freeware][Freeware Icon]
 - [Alfred](https://www.alfredapp.com/) - Boosts your efficiency and productivity.
 - [BetterTouchTool](https://folivora.ai) - Configure gestures for mouse and actions for keyboard shortcuts.
 - [ClipMenu](http://www.clipmenu.com/) - ClipBoard History Manager. [![Open-Source Software][OSS Icon]](https://github.com/naotaka/ClipMenu) ![Freeware][Freeware Icon]


### PR DESCRIPTION
0. [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
1. [x] I confirm that I have read and understood the sections about "AI"-adjacent software
2. [x] Project URL: https://czxxxczx73-cell.github.io/chat-session-managers/
3. [x] Why should this project be added: Chat Session Managers is a native, non-Electron macOS utility for managing session-history files already stored on disk by Codex, Claude Code, and Grok. It does not prompt an LLM or call generative APIs; its purpose is local file browsing and lifecycle management.
4. [x] End all descriptions with a full stop/period
5. [x] Entry is ordered alphabetically
6. [x] Appropriate icon(s) added if applicable (OSS, freeware)

Chat Session Managers is free, MIT-licensed, and distributed as a Universal 2 macOS download for Apple Silicon and Intel Macs.

- Product page: https://czxxxczx73-cell.github.io/chat-session-managers/
- Source code: https://github.com/czxxxczx73-cell/chat-session-managers
- 20-second live UI demo: https://github.com/czxxxczx73-cell/chat-session-managers/releases/download/v2.0.1/chat-session-managers-demo-v2.mp4
