### PR TITLE
Add SupaSidebar to Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@
 - [ScreenTranslate](https://screentranslate.filient.ai/) - Capture any area or select text to translate instantly, fully on-device. [![Open-Source Software][OSS Icon]](https://github.com/hcmhcs/screenTranslate) ![Freeware][Freeware Icon]
 - [SelfControl](https://selfcontrolapp.com/) - Block access to distracting websites. [![Open-Source Software][OSS Icon]](https://github.com/SelfControlApp/selfcontrol/) ![Freeware][Freeware Icon]
 - [Simplenote](https://simplenote.com/) - Simple cross-platform note taking app with cloud-based syncing. ![Freeware][Freeware Icon]
+- [SupaSidebar](https://supasidebar.com/) - Arc-style sidebar for every browser on macOS to organize tabs, bookmarks, files, and apps in one place.
 - [Taskade](https://apps.apple.com/us/app/taskade-manage-anything/id1490048917/) - Real-time organization and task management tool.
 - [TaskPaper](https://www.taskpaper.com/) - Plain text to-do lists.
 - [Telephone](http://www.64characters.com/telephone/) - A SIP softphone. Make phone calls over the Internet or your company’s network. [![Open-Source Software][OSS Icon]](https://github.com/eofster/Telephone) ![Freeware][Freeware Icon]


### PR DESCRIPTION
0. [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
1. [x] I confirm that I have read and understood the sections about "AI"-adjacent software
2. [x] Project URL: https://supasidebar.com/
3. [x] Why should this project be added: SupaSidebar is a native Swift/SwiftUI app that adds an Arc-style sidebar to every browser on macOS, giving you one place to organize tabs, bookmarks, files, and apps across all of them. It is not an AI/LLM wrapper and is not built on Electron. Install: `brew install --cask supasidebar`.
4. [x] End all descriptions with a full stop/period
5. [x] Entry is ordered alphabetically
6. [x] Appropriate icon(s) added if applicable (OSS, freeware)

Disclosure: I'm the developer of SupaSidebar.