### PR TITLE
Add Burst2GIF (Lightroom burst-to-GIF/MP4 plugin) to Graphics

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@
 - [Acorn](https://secure.flyingmeat.com/acorn/) - A very Mac-like image editor with a comprehensive feature set.
 - [Affinity Designer](https://affinity.serif.com/en-us/designer/) - Vector image design tool, possible Adobe Illustrator alternative.
 - [Affinity Photo](https://affinity.serif.com/en-us/photo/) - Raster image design tool, possible Adobe Photoshop alternative.
+- [Burst2GIF](https://www.marektopolar.com/tools/burst2gif) - Lightroom Classic plugin that converts burst photo sequences into MP4 videos or animated GIFs.
 - [GifCapture](https://github.com/onmyway133/GifCapture) - Record GIF screencasts. [![Open-Source Software][OSS Icon]](https://github.com/onmyway133/GifCapture)
 - [GIPHY Capture](https://itunes.apple.com/us/app/giphy-capture.-the-gif-maker/id668208984) - Capture and share GIFs on the desktop. ![Freeware][Freeware Icon]
 - [Image2icon](http://www.img2icnsapp.com) - Create and personalize icons from your pictures. ![Freeware][Freeware Icon]


### PR DESCRIPTION
Burst2GIF is a plugin for Adobe Lightroom Classic that converts burst photo sequences into MP4 videos or animated GIFs directly inside Lightroom — no Photoshop or separate video editor needed.

- Live preview with FPS control (auto-detected from EXIF)
- Exports MP4 (H.264, up to 6K) or GIF, preserves develop edits
- Free version available; one-time $29 license
- macOS, Lightroom Classic 10.0+, notarized by Apple

Added to **Graphics** in alphabetical order, matching the existing entry format. Similar tools already listed: GifCapture, GIPHY Capture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)