### PR TITLE
Add TickerNotch

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,7 @@
 - [Strongbox](https://strongboxsafe.com/) - Secure Password Management for iOS and MacOS. Open Source. Compatible with KeePass and Password Safe. [![Open-Source Software][OSS Icon]](https://github.com/strongbox-password-safe/Strongbox)
 - [TeamViewer](https://www.teamviewer.com/en/) - Remotely control another computer.
 - [TextBar](http://www.richsomerfield.com/apps/) - TextBar is a tiny but powerful app that lets you add any text to your MenuBar.
+- [TickerNotch](https://bitvibelabs.com/tickernotch/) - Live stock and crypto tickers, scrolling news and price alerts in the black bars beside the MacBook notch.
 - [Typeeto](http://mac.eltima.com/bluetooth-keyboard.html) - Lets you use your Mac's keyboard as a bluetooth keyboard to type on another devices.
 - [Typora](http://www.typora.io/) - Another minimal Markdown editor. ![Freeware][Freeware Icon]
 - [Ukelele](http://scripts.sil.org/cms/scripts/page.php?site_id=nrsi&id=ukelele) - Unicode Keyboard Layout Editor. ![Freeware][Freeware Icon]


### PR DESCRIPTION
TickerNotch is a native Swift menu bar app that turns the unused space beside the MacBook notch into a live market strip: watchlist tickers, scrolling RSS news and price alerts. Click a ticker for candlestick charts.

Free version works indefinitely (1 ticker, 1 news channel, 1 alert), so maintainers can validate it without paying. Pro is $5/mo or $40 lifetime. Signed and notarized DMG, no account, no Electron. macOS 14+.

Direct download: https://bitvibelabs.com/tickernotch/TickerNotch-v0.12.4.dmg
