### PR TITLE
Add Flowtake to Video

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,7 @@
 
 ### Video
 
+- [Flowtake](https://jnx03.github.io/Flowtake/) - Local-first screen recorder and timeline editor for polished developer demos. [![Open-Source Software][OSS Icon]](https://github.com/JNX03/Flowtake) ![Freeware][Freeware Icon]
 - [HandBrake](https://handbrake.fr/) - High performance video encoding and conversion tools with a nice GUI. [![Open-Source Software][OSS Icon]](https://github.com/HandBrake/HandBrake)
 - [IINA](https://lhc70000.github.io/iina/) - Media player with a minimalist design. [![Open-Source Software][OSS Icon]](https://github.com/lhc70000/iina) ![Freeware][Freeware Icon]
 - [mpv](https://mpv.io/) - Media player. [![Open-Source Software][OSS Icon]](https://github.com/mpv-player/mpv)


### PR DESCRIPTION
## Description

Adds Flowtake to the Video section. Flowtake is a free, MIT-licensed, local-first screen recorder and timeline editor with a published universal macOS build.

The entry uses the list's existing open-source and freeware markers, and the project and website links were verified before submission.
