### PR TITLE
Add AskClean to Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@
 - [APNGb](https://github.com/mancunianetz/APNGb) - .apng image assembler/disassembler app. [![Open-Source Software][OSS Icon]](https://github.com/mancunianetz/APNGb) ![Freeware][Freeware Icon]
 - [AppCleaner](http://freemacsoft.net/appcleaner/) - Uninstall your apps easily. ![Freeware][Freeware Icon]
 - [Artify](https://github.com/NghiaTranUIT/artify-macos) - A macOS X application for bringing dedicatedly 18th century Arts to everyone. [![Open-Source Software][OSS Icon]](https://github.com/NghiaTranUIT/artify-macos) ![Freeware][Freeware Icon]
+- [AskClean](https://www.askclean.app) - AI-powered disk cleanup that explains every item and asks before deleting. Trash-safe deletes, never touches photos or documents.
 - [Bartender](https://www.macbartender.com/) - Organize your menu bar apps.
 - [Batch Image Resizer](http://www.ironstarmedia.co.uk/resources/osx-image-resizer/) - Resize a large number of images quickly on your computer. ![Freeware][Freeware Icon]
 - [BeardedSpice](https://github.com/beardedspice/beardedspice) - Control web based media players with the media keys found on Mac keyboards. [![Open-Source Software][OSS Icon]](https://github.com/beardedspice/beardedspice) ![Freeware][Freeware Icon]


### PR DESCRIPTION
## What

Adds **[AskClean](https://www.askclean.app)** to the *Utilities* section (alphabetical position, between Artify and Bartender).

AskClean is an AI-powered disk cleanup app for macOS:

- Explains every scanned item in plain language and **asks before deleting** — per-item confirmation, no bulk wipes
- Deletes go to the Trash (restorable); photo library, documents and system files are never touched
- 12 scan categories including developer caches (Xcode DerivedData, npm, simulators), app leftovers, duplicates and large files
- Free unlimited scanning; one-time purchase to clean — no subscription
- macOS 12+, Apple Silicon & Intel, Developer ID signed and notarized

Website: https://www.askclean.app (28 languages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)