### PR TITLE
CleanMyMac CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,6 +380,7 @@
 ## Command Line Utilities
 
 - [Awesome macOS Command Line](https://github.com/herrbischoff/awesome-osx-command-line) - Use your macOS terminal shell to do awesome things.
+- [CleanMyMac CLI](https://github.com/MacPaw/cleanmymac-cli) - Clean Xcode, Docker, Homebrew, and developer caches, analyze storage, and reclaim disk space from the terminal.
 - [m-cli](https://github.com/rgcr/m-cli) -  Swiss Army Knife for macOS.
 - [Mac-CLI](https://github.com/guarinogabriel/Mac-CLI) -  macOS command line tools for developers.
 - [Mocker](https://github.com/us/mocker) - Docker-compatible container CLI for macOS, built on Apple's Containerization framework. [![Open-Source Software][OSS Icon]](https://github.com/us/mocker) ![Freeware][Freeware Icon]


### PR DESCRIPTION
Clean Xcode, Docker, Homebrew, and developer caches, analyze storage, and reclaim disk space from the terminal.

0. [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
1. [x] I confirm that I have read and understood the sections about "AI"-adjacent software
2. [x] Project URL: https://github.com/MacPaw/cleanmymac-cli
3. [x] Why should this project be added: CleanMyMac CLI is a terminal-first cleanup tool for developers on macOS. It clears caches, build artifacts, and system junk from common developer tools (Xcode, Docker, Homebrew, package managers), analyzes disk usage, and reclaims storage — all without leaving the command line. It fits naturally in the Command Line Utilities section.
4. [x] End all descriptions with a full stop/period
5. [x] Entry is ordered alphabetically
6. [x] Appropriate icon(s) added if applicable
