### PR TITLE
Add AgentBar (menu bar status for AI coding agents)

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@
 
 ### Developers
 
+- [AgentBar](https://github.com/michalstrnadel/AgentBar) - Menu bar status for AI coding agents (Claude Code, Codex, Copilot) with one-click Allow/Deny of Claude Code permission prompts. [![Open-Source Software][OSS Icon]](https://github.com/michalstrnadel/AgentBar) ![Freeware][Freeware Icon]
 - [Anvil](http://anvilformac.com/) - Serve up static sites and Rack apps with simple URLs and zero configuration. ![Freeware][Freeware Icon]
 - [Base 2](http://menial.co.uk/base/) - A GUI for managing SQLite databases.
 - [CocoaRestClient](https://mmattozzi.github.io/cocoa-rest-client) - An app for testing REST endpoints. [![Open-Source Software][OSS Icon]](https://github.com/mmattozzi/cocoa-rest-client) ![Freeware][Freeware Icon]


### PR DESCRIPTION
Adds [AgentBar](https://github.com/michalstrnadel/AgentBar) to the Developers section — a free, MIT-licensed native macOS menu bar app showing live status of AI coding agent sessions (Claude Code, Codex, GitHub Copilot) with one-click Allow/Always/Deny of Claude Code permission prompts from the menu bar. Native Swift/AppKit, universal binary, macOS 12+, prebuilt releases. Entry follows the existing format with OSS and Freeware icons.