### PR TITLE
Add philosophic moon to Command Line Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,6 +384,7 @@
 - [Mac-CLI](https://github.com/guarinogabriel/Mac-CLI) -  macOS command line tools for developers.
 - [Mocker](https://github.com/us/mocker) - Docker-compatible container CLI for macOS, built on Apple's Containerization framework. [![Open-Source Software][OSS Icon]](https://github.com/us/mocker) ![Freeware][Freeware Icon]
 - [mas](https://github.com/mas-cli/mas) - A CLI for the Mac App Store. [![Open-Source Software][OSS Icon]](https://github.com/mas-cli/mas) ![Freeware][Freeware Icon]
+- [philosophic moon](https://github.com/SorBalda/philosophic-moon) - A tiny cozy moon in your terminal: stargaze through meteor showers, water a plant the whole internet waters together, and read philosophy under the stars. ![Freeware][Freeware Icon]
 - [quokka](https://github.com/dutradotdev/quokka) - Inspect and clean a USB-connected iPhone from the terminal. No jailbreak required. [![Open-Source Software][OSS Icon]](https://github.com/dutradotdev/quokka) ![Freeware][Freeware Icon]
 
 ## macOS Utilities


### PR DESCRIPTION
0. [x] I have read the Contribution Guidelines
1. [x] I confirm that I have read and understood the sections about "AI"-adjacent software
2. [x] Project URL: https://github.com/SorBalda/philosophic-moon
3. [x] Why should this project be added: it's a small, cozy terminal app for macOS (Apple Silicon build on Releases today, Intel planned) - stargaze through meteor showers, water a shared plant, read philosophy under the stars. Free, closed-source, single binary, works offline. Not an AI tool.
4. [x] End all descriptions with a full stop/period
5. [x] Entry is ordered alphabetically
6. [x] Appropriate icon(s) added if applicable (OSS, freeware) - Freeware icon only (closed source)