### PR TITLE
Add napwatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,6 +393,7 @@
 - [Command Line Utilities Part 2](http://www.mitchchn.me/2014/and-eight-hundred-more/)
 - [EnvPane](https://github.com/hschmidt/EnvPane) - An preference pane for environment variables. [![Open-Source Software][OSS Icon]](https://github.com/hschmidt/EnvPane) ![Freeware][Freeware Icon]
 - [Glances](https://github.com/nicolargo/glances) - System monitoring tool that runs in terminal. [![Open-Source Software][OSS Icon]](https://github.com/nicolargo/glances) ![Freeware][Freeware Icon]
+- [napwatch](https://github.com/Tuguberk/napwatch) - A terminal UI for diagnosing and controlling macOS power/battery behavior: dark wakes, Power Nap, and live drain rate. [![Open-Source Software][OSS Icon]](https://github.com/Tuguberk/napwatch) ![Freeware][Freeware Icon]
 - [Thread on StackExchange](https://apple.stackexchange.com/questions/12161/os-x-terminal-must-have-utilities)
 
 


### PR DESCRIPTION
0. [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
1. [x] I confirm that I have read and understood the sections about "AI"-adjacent software
2. [x] Project URL: https://github.com/Tuguberk/napwatch
3. [x] Why should this project be added: napwatch is an open-source (MIT), free terminal UI for diagnosing and controlling macOS power/battery behavior — instant-watt battery draw, a live sleep/wake event feed that surfaces Power Nap-driven "dark wakes" silently draining the battery overnight, a power-ranked process table with kill/renice, and toggles for Power Nap, Wake for network access, Low Power Mode, Standby, and TCP Keepalive. It's a native terminal tool (not AI-adjacent), fits alongside Glances as a terminal-based system monitor.
4. [x] End all descriptions with a full stop/period
5. [x] Entry is ordered alphabetically (placed between Glances and Thread on StackExchange in macOS Utilities)
6. [x] Appropriate icon(s) added if applicable (OSS, freeware) — no separate website, so both the primary link and OSS icon point to the GitHub repo, per the contributing guide.