### PR TITLE
Add Mainspring to Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,7 @@
 - [MacDown](http://macdown.uranusjr.com/) - Markdown editor. [![Open-Source Software][OSS Icon]](https://github.com/MacDownApp/macdown) ![Freeware][Freeware Icon]
 - [Mackup](https://github.com/lra/mackup) - Keep your application settings in sync. [![Open-Source Software][OSS Icon]](https://github.com/lra/mackup) ![Freeware][Freeware Icon]
 - [MacPass](https://macpass.github.io/) - Password Manager. [![Open-Source Software][OSS Icon]](https://github.com/MacPass/MacPass) ![Freeware][Freeware Icon]
+- [Mainspring](https://trymainspring.com/) - Turn 90+ hidden macOS settings into one-click, reversible toggles, each with an undo button.
 - [Media Converter](http://media-converter.sourceforge.net/) - Simple (drag and drop) but advanced media conversion. [![Open-Source Software][OSS Icon]](https://sourceforge.net/p/media-converter/code/ci/master/tree/) ![Freeware][Freeware Icon]
 - [Menubar Colors](https://github.com/nvzqz/Menubar-Colors) - Convenient access to the system color panel. [![Open-Source Software][OSS Icon]](https://github.com/nvzqz/Menubar-Colors) ![Freeware][Freeware Icon]
 - [MenuMeters](http://member.ipmu.jp/yuji.tachikawa/MenuMetersElCapitan/) - A set of CPU, memory, disk, and network monitoring tools for macOS. [![Open-Source Software][OSS Icon]](https://github.com/yujitach/MenuMeters)


### PR DESCRIPTION
Adds Mainspring, a native macOS utility that turns 90+ hidden system settings into one-click, reversible toggles, each with an undo button (Dock, Finder, keyboard, trackpad, privacy, performance, screenshots, menu bar).

- Placed alphabetically in **Utilities** (after MacPass, before Media Converter).
- No badge, consistent with other commercial apps in the list (e.g. Little Snitch, Moom).
- Signed and notarized by Apple. https://trymainspring.com