### PR TITLE
Add Pulse to Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,7 @@
 - [OnyX](http://www.titanium.free.fr/) -  Multifunction utility to verify disks and files, run cleaning and system maintenance tasks, configure hidden options and more. ![Freeware][Freeware Icon]
 - [Paparazzi](http://derailer.org/paparazzi/) - A small utility that makes screenshots of webpages. ![Freeware][Freeware Icon]
 - [Paragon NTFS](http://www.paragon-drivers.com/ntfs-mac/) - World fastest NTFS driver.
+- [Pulse](https://github.com/emgeorrk/pulse) - Menu bar system monitor with live CPU, memory, temperature, fan, network, disk, power, and battery stats. [![Open-Source Software][OSS Icon]](https://github.com/emgeorrk/pulse) ![Freeware][Freeware Icon]
 - [PureMac](https://github.com/momenbasel/PureMac) - Free and open-source macOS cleaner that removes system caches, Xcode junk, Homebrew cache, and more with no telemetry or network calls. [![Open-Source Software][OSS Icon]](https://github.com/momenbasel/PureMac) ![Freeware][Freeware Icon]
 - [Radio Silence](https://radiosilenceapp.com) - Simple to use firewall and network monitor.
 - [Microsoft Remote Desktop Connection Client](https://itunes.apple.com/us/app/microsoft-remote-desktop/id715768417) - Remote Desktop Connection Client lets you connect from your Macintosh computer to a Windows-based computer.


### PR DESCRIPTION
0. [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
1. [x] I confirm that I have read and understood the sections about "AI"-adjacent software
2. [x] Project URL: https://github.com/emgeorrk/pulse
3. [x] Why should this project be added:
   - A feature-equivalent macOS counterpart of [Vitals](https://github.com/corecoding/Vitals), the popular GNOME Shell system-monitor extension that never existed on macOS — the same idea, rebuilt from scratch for the Mac.
   - Free, open-source (MIT) menu bar system monitor with live CPU, memory, temperature, fan, network, disk, power, and battery stats.
   - Reads everything from userspace — no sudo, no elevated privileges, no kernel extensions.
   - Native app (Go + CGO over IOKit / SMC / HID / IOReport), tiny footprint, not Electron.
   - Not AI-adjacent: no LLMs, no generative tools, no network calls at all.
   - Supports Apple Silicon and Intel; installable via a Homebrew tap or GitHub releases.
4. [x] End all descriptions with a full stop/period
5. [x] Entry is ordered alphabetically (between *Paragon NTFS* and *PureMac* in *Utilities*)
6. [x] Appropriate icon(s) added if applicable (OSS, freeware) — both OSS and Freeware; the app has no website, so both links point to the source code
