### PR TITLE
Add Viaduct to Developers

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@
 - [Unused](https://jeffhodnett.github.io/Unused/) - An app for checking Xcode projects for unused resources. [![Open-Source Software][OSS Icon]](https://github.com/jeffhodnett/Unused) ![Freeware][Freeware Icon]
 - [Vagrant Manager](http://vagrantmanager.com) - Manage your vagrant machines in one place with Vagrant Manager for macOS. [![Open-Source Software][OSS Icon]](https://github.com/lanayotech/vagrant-manager/) ![Freeware][Freeware Icon]
 - [Versions](http://versionsapp.com/) - SVN GUI client for Mac.
+- [Viaduct](https://magicelklabs.com) - Converts a Google Chrome extension into a Safari web extension from the command line, shimming Chrome APIs that Safari lacks. [![Open-Source Software][OSS Icon]](https://github.com/magicelk235/Viaduct-CLI) ![Freeware][Freeware Icon]
 - [WWDC](https://github.com/insidegui/WWDC) - The WWDC app. [![Open-Source Software][OSS Icon]](https://github.com/insidegui/WWDC)
 - [Xcodes](https://github.com/RobotsAndPencils/XcodesApp) - Install and switch between multiple versions of Xcode. [![Open-Source Software][OSS Icon]](https://github.com/RobotsAndPencils/XcodesApp) ![Freeware][Freeware Icon]
 


### PR DESCRIPTION
Adds Viaduct to the Developers section.

Viaduct converts a Google Chrome extension into a Safari web extension from the command line, including shims for Chrome APIs that Safari doesn't support. The engine is open source (MIT) and free.

- Site: https://magicelklabs.com
- Source: https://github.com/magicelk235/Viaduct-CLI

Entry placed alphabetically and formatted with the OSS and Freeware badges to match the rest of the section.