### PR TITLE
Add Noden as a macOS client for SSH, SFTP, RDP

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,7 @@
 ### Terminal
 
 - [iTerm 2](https://www.iterm2.com/) - A terminal emulator. [![Open-Source Software][OSS Icon]](https://github.com/gnachman/iTerm2) ![Freeware][Freeware Icon]
+- [Noden](https://noden.useroamteknoloji.com/) - Native macOS client for SSH, SFTP and RDP in one window, with an optional AI command assistant. ![Freeware][Freeware Icon]
 
 
 ### Utilities


### PR DESCRIPTION
Adds Noden to the Terminal section (placed after iTerm 2, alphabetical order).

I have read the contribution guidelines and the section about "AI"-adjacent software. Noden is a native macOS utility — an SSH, SFTP and RDP client — not an AI product; the AI command assistant is an optional, secondary feature, so it fits the guidelines.

Project URL: https://noden.useroamteknoloji.com

Why it should be added: Noden is a native macOS client that combines SSH, SFTP and RDP in one window, with a dual-pane SFTP file manager. It belongs in the Terminal section alongside iTerm 2. The entry is ordered alphabetically, the description ends with a full stop, and the Freeware icon is included.