### PR TITLE
Add Yap to Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,7 @@
 - [Telephone](http://www.64characters.com/telephone/) - A SIP softphone. Make phone calls over the Internet or your company’s network. [![Open-Source Software][OSS Icon]](https://github.com/eofster/Telephone) ![Freeware][Freeware Icon]
 - [TextExpander](https://smilesoftware.com/textexpander) - Create custom keyboard shortcuts for frequently-used text and pictures.
 - [Timing](https://timingapp.com/) - Automatic time and productivity tracking for Mac. Helps you stay on track with your work and ensures no billable hours get lost if you are billing hourly.
+- [Yap](https://github.com/FrigadeHQ/yap) - On-device voice dictation from the menu bar, with a hotkey to talk and no model to download. [![Open-Source Software][OSS Icon]](https://github.com/FrigadeHQ/yap) ![Freeware][Freeware Icon]
 
 
 ### Sharing Files


### PR DESCRIPTION
Adds Yap, an open source menu bar app for on-device voice dictation on macOS.

You set a hotkey, talk, and the text is pasted into whatever field you were typing in. It runs offline in native Swift with no model to download and no network code. MIT licensed.

https://github.com/FrigadeHQ/yap

Placed alphabetically at the end of Productivity, with the open-source and freeware badges.