### PR TITLE
Add Qwen Scribe to Audio

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@
 - [krisp](https://krisp.ai/) - AI-powered app that removes background noise and echo from meetings leaving only human voice.
 - [Murmur](https://murmurtts.com/) - On-device text-to-speech studio with 860+ voices, voice cloning, and four AI models running entirely on Apple Silicon via MLX.
 - [Plug](https://plugformac.com) - Discover and listen to music from Hype Machine. [![Open-Source Software][OSS Icon]](https://github.com/wulkano/Plug) ![Freeware][Freeware Icon]
+- [Qwen Scribe](https://github.com/VladUZH/qwen-scribe) - Private, local transcription and system-wide dictation running Qwen3-ASR entirely on Apple Silicon via MLX. [![Open-Source Software][OSS Icon]](https://github.com/VladUZH/qwen-scribe) ![Freeware][Freeware Icon]
 - [Recordia](https://sindresorhus.com/recordia) - Record audio directly from the menu bar or with a global keyboard shortcut.
 - [VOX Player](https://coppertino.com/vox/mac) - Play numerous lossy and lossless audio formats.
 - [XLD](http://tmkk.undo.jp/xld/index_e.html) - Rip/Decode/convert/play various "lossless" audio files. [![Open-Source Software][OSS Icon]](https://code.google.com/archive/p/xld/source) ![Freeware][Freeware Icon]


### PR DESCRIPTION
Adds [Qwen Scribe](https://github.com/VladUZH/qwen-scribe) to **Audio**.

An Apache-2.0 macOS app for private, fully local speech-to-text on Apple
Silicon. It runs Qwen3-ASR on the Mac's Metal GPU through MLX — no account, no
API key, no cloud service, and audio never leaves the machine. It handles both
drag-and-drop file and video transcription (word timestamps, SRT export) and
system-wide dictation: hold right Command in any text field, speak, release,
and the text lands at the cursor.

It sits naturally alongside Murmur, which covers the on-device MLX
text-to-speech side of the same workflow.

Disclosure: I am the author of the project.

- [x] Searched existing entries — no duplicate
- [x] Placed alphabetically in `Audio` (after Plug, before Recordia)
- [x] One-sentence description
- [x] Open-source and freeware icons applied, matching the section's convention
- [x] No trailing whitespace
