### PR TITLE
Add Performance Monitor to Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,7 @@
 - [OnyX](http://www.titanium.free.fr/) -  Multifunction utility to verify disks and files, run cleaning and system maintenance tasks, configure hidden options and more. ![Freeware][Freeware Icon]
 - [Paparazzi](http://derailer.org/paparazzi/) - A small utility that makes screenshots of webpages. ![Freeware][Freeware Icon]
 - [Paragon NTFS](http://www.paragon-drivers.com/ntfs-mac/) - World fastest NTFS driver.
+- [Performance Monitor](https://perfmon.knhome.nl) - Menu bar system monitor for CPU, memory, network, disk, GPU, per-sensor temperatures, SSD wear, and battery health. No telemetry. [![Open-Source Software][OSS Icon]](https://github.com/inequitas/performancemonitor) ![Freeware][Freeware Icon]
 - [PureMac](https://github.com/momenbasel/PureMac) - Free and open-source macOS cleaner that removes system caches, Xcode junk, Homebrew cache, and more with no telemetry or network calls. [![Open-Source Software][OSS Icon]](https://github.com/momenbasel/PureMac) ![Freeware][Freeware Icon]
 - [Radio Silence](https://radiosilenceapp.com) - Simple to use firewall and network monitor.
 - [Microsoft Remote Desktop Connection Client](https://itunes.apple.com/us/app/microsoft-remote-desktop/id715768417) - Remote Desktop Connection Client lets you connect from your Macintosh computer to a Windows-based computer.


### PR DESCRIPTION
Adds [Performance Monitor](https://github.com/inequitas/performancemonitor), a free and open-source menu bar system monitor for macOS.

It shows CPU, memory, network, disk, GPU, per-sensor temperatures and fan speeds, SSD wear level, system power draw in watts, and battery health, with detail windows per metric, a 30-day history view, and threshold alerts. MIT licensed, no telemetry, and it is translated into 7 languages.

Placed alphabetically in Utilities between Paragon NTFS and PureMac, using the existing entry format with the open-source and freeware badges.

One thing worth stating plainly: the app requires Apple Silicon (M1 or later) on macOS 14+, and it is ad-hoc signed rather than notarised, so the first launch needs right-click then Open. That is documented on both the site and the README rather than left as a surprise.