### PR TITLE
Add SADFinder to Finder

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@
 - [Path Finder](http://www.cocoatech.com/pathfinder/) - A powerful dual-pane browser alternative to Finder.
 - [Pathly](https://pathly.sophinauta.com/) - Copy any file or folder path from Finder: full, directory, URL, or Git-relative.
 - [Quicklook-Plugins](https://github.com/sindresorhus/quick-look-plugins) - List of extra quicklook plugins to enable previewing more filetypes in the Finder.
+- [SADFinder](https://sadfinder.com/) - Native Finder alternative with Windows-style shortcuts, tabs, and an editable path bar.
 - [TotalFinder](http://totalfinder.binaryage.com/) - A powerful alternative to Finder.
 - [XtraFinder](https://www.trankynam.com/xtrafinder/) - Adds useful features to Finder. ![Freeware][Freeware Icon]
 


### PR DESCRIPTION
0. [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
1. [x] I confirm that I have read and understood the sections about AI-adjacent software
2. [x] Project URL: https://sadfinder.com/
3. [x] Why should this project be added: SADFinder is a native, non-Electron macOS Finder alternative with Windows-style shortcuts, tabs, an editable path bar, and a direct seven-day free trial.
4. [x] End all descriptions with a full stop/period
5. [x] Entry is ordered alphabetically
6. [x] Appropriate icon(s) added if applicable (OSS, freeware): not applicable; SADFinder is commercial