### PR TITLE
Add IraVoice to Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@
 - [HyperDock](https://bahoom.com/hyperdock/) - Select individual application window.
 - [iCMD](https://icmd.app) - Fuzzy menubar search and vim emulation.
 - [Instant Translate](https://insttranslate.com/mac) - Translate speech and text between 100+ languages from the menu bar.
+- [IraVoice](https://iravoice.com/) - On-device push-to-talk dictation that types into any Mac app.
 - [ItsyCal](https://www.mowglii.com/itsycal/) - A tiny menubar calendar to display your Mac Calendar app events. [![Open-Source Software][OSS Icon]](https://github.com/sfsam/Itsycal) ![Freeware][Freeware Icon]
 - [Karabiner](https://pqrs.org/osx/karabiner/) - A powerful keyboard customizer. [![Open-Source Software][OSS Icon]](https://github.com/tekezo/Karabiner) ![Freeware][Freeware Icon]
 - [Keyboard Maestro](http://www.keyboardmaestro.com) - Automate routine actions based on triggers from keyboard, menu, location, added devices, and more.


### PR DESCRIPTION
0. [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
1. [x] I confirm that I have read and understood the sections about "AI"-adjacent software
2. [x] Project URL: https://iravoice.com/
3. [x] Why should this project be added: IraVoice is a native Swift/SwiftUI utility that provides on-device push-to-talk dictation across Mac apps. It uses Apple's specialized local speech-recognition framework rather than an LLM, chatbot, agent, or generative prompt wrapper. The signed and notarized Apple-silicon build has a standalone three-day free trial. I maintain IraVoice and am disclosing that relationship.
4. [x] End all descriptions with a full stop/period
5. [x] Entry is ordered alphabetically
6. [x] Appropriate icon(s) added if applicable (OSS, freeware)

Validation:
- Canonical project URL returns HTTP 200.
- The entry is present exactly once under Productivity.
- No OSS or freeware marker was added because IraVoice is commercial closed-source software.
