### PR TITLE
Add Performance Monitor to Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,7 @@
 - [OnyX](http://www.titanium.free.fr/) -  Multifunction utility to verify disks and files, run cleaning and system maintenance tasks, configure hidden options and more. ![Freeware][Freeware Icon]
 - [Paparazzi](http://derailer.org/paparazzi/) - A small utility that makes screenshots of webpages. ![Freeware][Freeware Icon]
 - [Paragon NTFS](http://www.paragon-drivers.com/ntfs-mac/) - World fastest NTFS driver.
+- [Performance Monitor](https://perfmon.knhome.nl) - Menu bar system monitor for CPU, memory, network, disk, GPU, per-sensor temperatures, SSD wear, and battery health. No telemetry. [![Open-Source Software][OSS Icon]](https://github.com/inequitas/performancemonitor) ![Freeware][Freeware Icon]
 - [Pulse](https://www.pulseticker.app/) - Native menu bar market tracker for stocks, cryptocurrencies, indices, ETFs, and portfolio P&L. [![Open-Source Software][OSS Icon]](https://github.com/fatwang2/Pulse) ![Freeware][Freeware Icon]
 - [PureMac](https://github.com/momenbasel/PureMac) - Free and open-source macOS cleaner that removes system caches, Xcode junk, Homebrew cache, and more with no telemetry or network calls. [![Open-Source Software][OSS Icon]](https://github.com/momenbasel/PureMac) ![Freeware][Freeware Icon]
 - [Radio Silence](https://radiosilenceapp.com) - Simple to use firewall and network monitor.


### PR DESCRIPTION
<!-- Thanks for contributing to awesome-macOS  -->

<!-- Please fill out the following: -->

0. [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
1. [x] I confirm that I have read and understood the sections about "AI"-adjacent software
2. [x] Project URL: https://github.com/inequitas/performancemonitor (website: https://perfmon.knhome.nl)
3. [x] Why should this project be added: A free, open-source menu bar system monitor. It reads CPU, memory, network, disk, GPU, per-sensor temperatures and fan speeds, SSD wear level via NVMe SMART, system power draw in watts, and battery health, with a detail window per metric and a 30-day history view. MIT licensed, no telemetry, and no third-party dependencies. It is a system monitor rather than an interface to a generative tool, so the "AI"-adjacent exclusion does not apply.
4. [x] End all descriptions with a full stop/period
5. [x] Entry is ordered alphabetically
6. [x] Appropriate icon(s) added if applicable (OSS, freeware)

<!--

Again, please read https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md if you didn't yet.
If you don't fill out this template or replace it wholesale, your pull request will be closed without discussion.

-->

---

Note: this replaces #956, which I opened with a custom description instead of this template. That was my mistake, and I have since read the guidelines properly. The entry itself is unchanged apart from a rebase onto current `master`, where I kept it alphabetically ahead of the newly added Pulse entry. Requires Apple Silicon on macOS 14 or newer.
