### PR TITLE
Add SFTPro

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,6 +374,7 @@
 - [Catch](http://www.giorgiocalderolla.com/index.html#catch) - The easiest way to use ShowRSS. [![Open-Source Software][OSS Icon]](https://github.com/mipstian/catch/) ![Freeware][Freeware Icon]
 - [Clocker](https://itunes.apple.com/us/app/clocker-menubar-world-clock/id1056643111?ls=1&mt=12) - Check time in multiple timezones from your Mac menubar. [![Open-Source Software][OSS Icon]](https://github.com/Abhishaker17/Clocker) ![Freeware][Freeware Icon]
 - [Juice](https://github.com/brianmichel/Juice) - Make your battery information a bit more interesting. [![Open-Source Software][OSS Icon]](https://github.com/brianmichel/Juice) ![Freeware][Freeware Icon]
+- [SFTPro](https://sftpro.dev) - A native SFTP client with an in-place editor, transfer queue, and SSH-key authentication.
 - [Sonora](https://github.com/sonoramac/Sonora) -  A minimal, beautifully designed music player. [![Open-Source Software][OSS Icon]](https://github.com/sonoramac/Sonora) ![Freeware][Freeware Icon]
 - [Spillo](https://bananafishsoftware.com/products/spillo/) - Powerful, beautiful and fast Pinboard client.
 - [Transmit](https://panic.com/transmit/) - A FTP client.


### PR DESCRIPTION
0. [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
1. [x] I confirm that I have read and understood the sections about "AI"-adjacent software
2. [x] Project URL: https://sftpro.dev
3. [x] Why should this project be added: SFTPro is a native macOS SFTP client built in SwiftUI — keyboard-first, with a color-coded file browser, an in-place editor with syntax highlighting, a transfer queue, and SSH-key/password auth. It's a commercial app with a free tier (free to download, browse, connect, and preview), so maintainers can validate it without purchase. No dedicated FTP category exists, so I placed it alongside its closest peer, Transmit, under Applications > Others.
4. [x] End all descriptions with a full stop/period
5. [x] Entry is ordered alphabetically
6. [x] Appropriate icon(s) added if applicable (OSS, freeware) — none apply: it is neither open-source nor free-of-charge, matching the Transmit entry.