### PR TITLE
Add Waindow to Window Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,6 +366,7 @@
 - [ShiftPlus](https://shiftplus.app/) - macOS workspace manager to switch workspaces, restore apps and windows across Spaces, monitors, and Macs in one click.
 - [Stay](https://cordlessdog.com/stay/) - Resize/position windows when displays change.
 - [Swish](https://highlyopinionated.co/swish/) - Control windows and applications with trackpad gestures.
+- [Waindow](https://www.waindow.app/) - Arrange windows with linked resizing, notes, capture, and Keep Awake. ![Freeware][Freeware Icon]
 - [yabai](https://github.com/koekeishiya/yabai) - Tiling window manager with focus follows mouse. [![Open-Source Software][OSS Icon]](https://github.com/koekeishiya/yabai) ![Freeware][Freeware Icon]
 
 ### Others


### PR DESCRIPTION
0. [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
1. [x] I confirm that I have read and understood the sections about "AI"-adjacent software
2. [x] Project URL: https://www.waindow.app/
3. [x] Why should this project be added: Waindow is a native, free macOS window utility with linked resizing, window-specific notes, long-page capture, and Keep Awake. It contains no embedded AI and is not a prompt wrapper; optional local Shortcuts, CLI, and MCP access expose the same existing utility actions.
4. [x] End all descriptions with a full stop/period
5. [x] Entry is ordered alphabetically
6. [x] Appropriate icon(s) added if applicable (freeware)