### PR TITLE
Add NoteGen to Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@
 - [Mac Mouse Fixer](https://www.macfix.click/) - Fixes accidental double-clicks and adds smooth scrolling, horizontal scrolling, and wheel zoom for external mice.
 - [MeetingBar](https://meetingbar.onrender.com) - Your meetings in MacOS status bar [![Open-Source Software][OSS Icon]](https://github.com/leits/MeetingBar) ![Freeware][Freeware Icon]
 - [MenubarX](https://MenubarX.app) - A powerful menu bar browser.
+- [NoteGen](https://notegen.top/) - Local-first Markdown notes app with capture, editing, file management, canvas, and optional sync. [![Open-Source Software][OSS Icon]](https://github.com/codexu/note-gen)
 - [OmniFocus](https://www.omnigroup.com/omnifocus) - An incredible task management platform for Mac, iPad, and iPhone.
 - [OmniOutliner](https://www.omnigroup.com/omnioutliner/) - Perfect for collecting information, outlining ideas, adding structure to any sort of writing, and much more.
 - [Pandan](https://apps.apple.com/app/id1569600264) - Time awareness in your menu bar. ![Freeware][Freeware Icon]


### PR DESCRIPTION
<!-- Thanks for contributing to awesome-macOS  -->

0. [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
1. [x] I confirm that I have read and understood the sections about "AI"-adjacent software
2. [x] Project URL: https://notegen.top/
3. [x] Why should this project be added:
   - NoteGen is a complete macOS notes application built with Tauri 2, not Electron.
   - Its core capture, Markdown editing, file management, canvas, search, and sync workflows work without configuring an AI provider.
   - AI-assisted organization is optional and is part of a broader note-taking workflow rather than the application's sole interface or purpose.
   - The application is GPL-3.0 open source and stores written notes as ordinary Markdown files in a user-selected workspace.
4. [x] The description ends with a period
5. [x] The entry is ordered alphabetically in Productivity
6. [x] The OSS icon is included and links to the source code

## Checks

- Confirmed no existing NoteGen entry or historical pull request
- Ran `git diff --check`
- Confirmed the project website and source repository are reachable
