### PR TITLE
Add Fletch to Developers

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@
 - [Cork](https://corkmac.app) - A fast, intuitive Homebrew GUI [![Open-Source Software][OSS Icon]](https://github.com/buresdv/Cork)
 - [Dash](https://kapeli.com/dash) - An API Documentation Browser and Code Snippet Manager.
 - [Decode](https://microcodingapps.com/products/decode.html) - Converts Xcode Interface Builder files (Xib and Storyboard files) to Swift source code.
+- [Fletch](https://fletch.sh/?utm_source=dir-awesome-macos) - Runs Claude Code, Codex, Cursor Agent, and OpenCode in sealed workspaces, giving each agent its own sandboxed clone of your repository and a served index of its symbols and call graph. [![Open-Source Software][OSS Icon]](https://github.com/fwdai/fletch) ![Freeware][Freeware Icon]
 - [Fork](https://git-fork.com/) - a fast and friendly git client for Mac.
 - [DevUtils](https://devutils.com) - All-in-one toolbox for developers. 42+ beautifully crafted useful developer tools, native macOS app, work offline.
 - [Gas Mask](https://github.com/2ndalpha/gasmask) - A simple hosts file manager which allows editing of host files and switching between them. [![Open-Source Software][OSS Icon]](https://github.com/2ndalpha/gasmask) ![Freeware][Freeware Icon]


### PR DESCRIPTION
Adds [Fletch](https://fletch.sh) to **Applications > Developers**.

Fletch is a native macOS app (Tauri 2, AGPL-3.0) for running AI coding agents. Each agent gets its own clone of the repository with its own writable `.git`, inside a macOS Seatbelt or Docker sandbox, so the working copy is never writable by an agent. A symbol and call-graph index of the repo is served to every agent over MCP, built in a throwaway mirror so nothing is written to the source repository.

- Repo: https://github.com/fwdai/fletch
- License: AGPL-3.0 (open source, free)
- Platform: macOS

Placed alphabetically between `Decode` and `Fork`, using the section's existing format with the `[OSS Icon]` and `[Freeware Icon]` badge references. One line added, no other changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)