### PR TITLE
Add AI Dictation

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@
 
 ### Productivity
 
+- [AI Dictation](https://aidictation.com) - Open-source voice-to-text app with offline recognition on supported Macs and optional cloud transcription and cleanup. [![Open-Source Software][OSS Icon]](https://github.com/writingmate/aidictation)
 - [Alfred](https://www.alfredapp.com/) - Boosts your efficiency and productivity.
 - [BetterTouchTool](https://folivora.ai) - Configure gestures for mouse and actions for keyboard shortcuts.
 - [ClipMenu](http://www.clipmenu.com/) - ClipBoard History Manager. [![Open-Source Software][OSS Icon]](https://github.com/naotaka/ClipMenu) ![Freeware][Freeware Icon]


### PR DESCRIPTION
0. [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
1. [x] I confirm that I have read and understood the sections about "AI"-adjacent software
2. [x] Project URL: https://aidictation.com
3. [x] Why should this project be added: AI Dictation is a native Swift voice-to-text app for macOS. It uses speech-recognition models as part of a dictation workflow and is not a prompt wrapper or an interface for chat or code-generation APIs. It offers offline recognition on supported Macs and optional cloud transcription and cleanup. Its native client source is MIT-licensed, and the website offers free access so maintainers can validate the app without payment.
4. [x] End all descriptions with a full stop/period
5. [x] Entry is ordered alphabetically (before Alfred in Productivity)
6. [x] Appropriate icon(s) added if applicable (the OSS icon links to the source repository; the Freeware icon is intentionally omitted because paid access is also offered)

This supersedes my closed attempt in #793 and addresses its missing contribution template and OSS icon.

Disclosure: I am affiliated with AI Dictation. This contribution was prepared with AI assistance and manually verified against the current website, repository, and macOS source on August 2, 2026.

Validation:

- `git diff --check`
- Productivity entries remain alphabetically ordered
- Both newly added URLs returned HTTP 200
- The repository's `awesome_bot` command checked all 411 unique URLs. The new URLs passed; the command still reports 10 unrelated pre-existing broken or unavailable links elsewhere in the README.
