### PR TITLE
Add Traveler's VPN

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,6 +466,7 @@ Ansible playbook to configure a development and desktop environment from a clean
 * [Shimo](https://www.shimovpn.com) - Fully-featured VPN client for Mac.
 * [SimpleumSafe](https://simpleum.com/) - Encrypt, organize and sync files with macOS or iOS.
 * [tinc](https://www.tinc-vpn.org) - Secure mesh VPN software. [![Open-Source Software][OSS Icon]](https://www.tinc-vpn.org/git/browse?p=tinc) ![Freeware][Freeware Icon]
+* [Traveler's VPN](https://travelersvpn.com/) - Smart split-tunnel travel VPN client for Outline/Shadowsocks, WireGuard and Trojan servers, built on sing-box.
 * [Tunnelblick](https://tunnelblick.net) - Easy to use OpenVPN client and GUI. [![Open-Source Software][OSS Icon]](https://github.com/Tunnelblick/Tunnelblick) ![Freeware][Freeware Icon]
 * [VeraCrypt](https://veracrypt.codeplex.com/) - Free and open source disk encryption software. [![Open-Source Software][OSS Icon]](https://veracrypt.codeplex.com/SourceControl/latest) ![Freeware][Freeware Icon]
 * [Viscosity](https://www.sparklabs.com/viscosity/) - Fully-featured OpenVPN client, ready for enterprise deployment.


### PR DESCRIPTION
Adds [Traveler's VPN](https://travelersvpn.com/), a smart split-tunnel travel VPN client for the Mac (native menu-bar app) built on the sing-box engine. It connects to user-supplied Outline/Shadowsocks, WireGuard, or Trojan servers and routes per destination, so local apps stay direct while blocked/home traffic tunnels. Placed alphabetically alongside the other VPN clients (Shimo, tinc, Tunnelblick, Viscosity).

Disclosure: I'm the developer.