### PR TITLE
Add Glyph to Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@
 - [Dropzone](https://aptonic.com/) - Create a popup grid of customizable actions that enhance productivity on your Mac.
 - [f.lux](https://justgetflux.com/) - Automatically adjust your computer screen to match lighting. ![Freeware][Freeware Icon]
 - [Fantastical](https://flexibits.com/fantastical) - Complete Calendar app replacement which uses natural language for creating events.
+- [Glyph](https://glyphformac.com/) - Offline-first notes for macOS, built around local Markdown files. [![Open-Source Software][OSS Icon]](https://github.com/SidhuK/Glyph)
 - [Hazel](https://www.noodlesoft.com/hazel.php) - Create rules to automatically keep your files organized.
 - [HazeOver](https://hazeover.com/) - Turn distractions down and focus on your current task.
 - [HyperDock](https://bahoom.com/hyperdock/) - Select individual application window.


### PR DESCRIPTION
## What changed

- Added Glyph to the Productivity section in alphabetical order.
- Linked the official website as the primary link and the source repository through the OSS badge.

## About Glyph

Glyph is an offline-first notes app for macOS built around local Markdown files.
Its source code is available under AGPL-3.0. The official macOS builds are
commercial one-time-purchase releases with a 7-day trial, so this entry uses the
OSS badge but not the Freeware badge.

## Validation

- Confirmed the entry follows the repository's required format and alphabetical ordering.
- Ran `git diff --check`.
