### PR TITLE
Add capd to Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@
 
 - [Alfred](https://www.alfredapp.com/) - Boosts your efficiency and productivity.
 - [BetterTouchTool](https://folivora.ai) - Configure gestures for mouse and actions for keyboard shortcuts.
+- [capd](https://capd.jxd.dev) - Menu bar capture and bookmarking app with full-text search, OCR, and a CLI. [![Open-Source Software][OSS Icon]](https://github.com/jamiedavenport/capd) ![Freeware][Freeware Icon]
 - [ClipMenu](http://www.clipmenu.com/) - ClipBoard History Manager. [![Open-Source Software][OSS Icon]](https://github.com/naotaka/ClipMenu) ![Freeware][Freeware Icon]
 - [CloudClip](http://www.thinkbitz.com/cloudclip/) - Sync your clipboard between your Mac and your iOS devices. ![Freeware][Freeware Icon]
 - [Dropzone](https://aptonic.com/) - Create a popup grid of customizable actions that enhance productivity on your Mac.


### PR DESCRIPTION
Adds [capd](https://github.com/jamiedavenport/capd) under Applications → Productivity.

capd is an open-source native macOS capture and bookmarking app — a Pinboard successor with a menu bar app and CLI. Features full-text search, OCR, and local-first storage.

Disclosure: I'm the author of capd.

- Added in alphabetical order within the section
- Follows the existing entry format, with OSS and Freeware badges