### PR TITLE
Add PinkDown

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,7 @@
 - [OnyX](http://www.titanium.free.fr/) -  Multifunction utility to verify disks and files, run cleaning and system maintenance tasks, configure hidden options and more. ![Freeware][Freeware Icon]
 - [Paparazzi](http://derailer.org/paparazzi/) - A small utility that makes screenshots of webpages. ![Freeware][Freeware Icon]
 - [Paragon NTFS](http://www.paragon-drivers.com/ntfs-mac/) - World fastest NTFS driver.
+- [PinkDown](https://3xian.github.io/PinkDown/) - Fast native split-pane Markdown editor and reader built in Rust. [![Open-Source Software][OSS Icon]](https://github.com/3xian/PinkDown) ![Freeware][Freeware Icon]
 - [Pulse](https://www.pulseticker.app/) - Native menu bar market tracker for stocks, cryptocurrencies, indices, ETFs, and portfolio P&L. [![Open-Source Software][OSS Icon]](https://github.com/fatwang2/Pulse) ![Freeware][Freeware Icon]
 - [PureMac](https://github.com/momenbasel/PureMac) - Free and open-source macOS cleaner that removes system caches, Xcode junk, Homebrew cache, and more with no telemetry or network calls. [![Open-Source Software][OSS Icon]](https://github.com/momenbasel/PureMac) ![Freeware][Freeware Icon]
 - [Radio Silence](https://radiosilenceapp.com) - Simple to use firewall and network monitor.


### PR DESCRIPTION
0. [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
1. [x] I confirm that I have read and understood the sections about AI-adjacent software. PinkDown does not include AI features.
2. [x] Project URL: https://3xian.github.io/PinkDown/
3. [x] Why should this project be added: PinkDown is a free, MIT-licensed native Markdown editor and reader for macOS and Windows, built in Rust with egui rather than Electron. It provides a focused split-pane source and live-preview workflow, supports UTF-8 and UTF-16 files, and ships installers for both Apple Silicon and Intel Macs.
4. [x] End all descriptions with a full stop/period
5. [x] Entry is ordered alphabetically
6. [x] Appropriate icon(s) added if applicable (OSS, freeware)