### PR TITLE
Add Breakdown to Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@
 - [BetterZip](https://macitbetter.com/) - A very capable and full-featured archive manager.
 - [BitBar](https://github.com/matryer/bitbar) - Display output of any script to the menu bar. [![Open-Source Software][OSS Icon]](https://github.com/matryer/bitbar) ![Freeware][Freeware Icon]
 - [Boring Notch](https://github.com/TheBoredTeam/boring.notch) - Turns your MacBook notch into a dynamic hub with media controls, calendar integration, and more. [![Open-Source Software][OSS Icon]](https://github.com/TheBoredTeam/boring.notch) ![Freeware][Freeware Icon]
+- [Breakdown](https://breakdown.live/) - Shows whether connection trouble starts with Wi-Fi, the ISP path, or the app.
 - [Burn](http://burn-osx.sourceforge.net/Pages/English/home.html) - No-nonsense burning of Data/Audio/Video CDs and DVDs, including copying. [![Open-Source Software][OSS Icon]](https://sourceforge.net/p/burn-osx/code-git/ci/master/tree/) ![Freeware][Freeware Icon]
 - [CheatSheet](https://www.cheatsheetapp.com/CheatSheet/) - Know your short cuts. ![Freeware][Freeware Icon]
 - [ClipboardCleaner](https://github.com/Zuehlke/Clipboard_Cleaner) - Automatically removes text formatting from the clipboard. [![Open-Source Software][OSS Icon]](https://github.com/Zuehlke/Clipboard_Cleaner) ![Freeware][Freeware Icon]


### PR DESCRIPTION
0. [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
1. [x] I confirm that I have read and understood the sections about "AI"-adjacent software. Breakdown is a network-diagnostics utility; optional local MCP access is secondary, not its main purpose.
2. [x] Project URL: https://breakdown.live/
3. [x] Why should this project be added: Breakdown is a native macOS menu-bar utility that continuously distinguishes connection trouble originating on Wi-Fi/LAN, the ISP path, or the app and retains evidence after intermittent issues pass. It is free for standard use, with an optional paid Pro tier and a seven-day Pro trial for validation.
4. [x] The description ends with a full stop/period.
5. [x] The entry is ordered alphabetically in Utilities.
6. [x] No OSS or Freeware icon was added because the app is closed source and also offers a paid Pro tier.