### PR TITLE
Add Envy (Productivity)

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@
 - [ClipMenu](http://www.clipmenu.com/) - ClipBoard History Manager. [![Open-Source Software][OSS Icon]](https://github.com/naotaka/ClipMenu) ![Freeware][Freeware Icon]
 - [CloudClip](http://www.thinkbitz.com/cloudclip/) - Sync your clipboard between your Mac and your iOS devices. ![Freeware][Freeware Icon]
 - [Dropzone](https://aptonic.com/) - Create a popup grid of customizable actions that enhance productivity on your Mac.
+- [Envy](https://envynote.app/) - Fast, local-first Markdown notes app with one-box search, in the Notational Velocity tradition. ![Freeware][Freeware Icon]
 - [f.lux](https://justgetflux.com/) - Automatically adjust your computer screen to match lighting. ![Freeware][Freeware Icon]
 - [Fantastical](https://flexibits.com/fantastical) - Complete Calendar app replacement which uses natural language for creating events.
 - [Hazel](https://www.noodlesoft.com/hazel.php) - Create rules to automatically keep your files organized.


### PR DESCRIPTION
Adds Envy under Productivity, placed alphabetically between Dropzone and f.lux.

Envy is a free, native macOS Markdown note-taking app: every note is a flat `.md` file in one folder, with one-box search-and-create in the Notational Velocity tradition, wiki-links, and no lock-in.

- Website: https://envynote.app
- Tagged Freeware (the license is proprietary, so no open-source badge).