### PR TITLE
Add Nori Clipboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@
 - [Mac Mouse Fixer](https://www.macfix.click/) - Fixes accidental double-clicks and adds smooth scrolling, horizontal scrolling, and wheel zoom for external mice.
 - [MeetingBar](https://meetingbar.onrender.com) - Your meetings in MacOS status bar [![Open-Source Software][OSS Icon]](https://github.com/leits/MeetingBar) ![Freeware][Freeware Icon]
 - [MenubarX](https://MenubarX.app) - A powerful menu bar browser.
+- [Nori Clipboard](https://noriclipboard.com/en) - Native clipboard history with Quick Paste and reusable ordered paste workflows.
 - [OmniFocus](https://www.omnigroup.com/omnifocus) - An incredible task management platform for Mac, iPad, and iPhone.
 - [OmniOutliner](https://www.omnigroup.com/omnioutliner/) - Perfect for collecting information, outlining ideas, adding structure to any sort of writing, and much more.
 - [Pandan](https://apps.apple.com/app/id1569600264) - Time awareness in your menu bar. ![Freeware][Freeware Icon]


### PR DESCRIPTION
Disclosure: I am the developer of Nori Clipboard.

0. [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
1. [x] I confirm that I have read and understood the sections about "AI"-adjacent software
2. [x] Project URL: https://noriclipboard.com/en
3. [x] Why should this project be added: Nori is a native SwiftUI clipboard manager for macOS 15 and later. Its Flow Replay feature saves an ordered sequence of clips as a reusable paste workflow, which is distinct from the existing Paste entry. It offers a complete standalone 14-day trial, is not an Electron app, and its main purpose does not involve generative AI.
4. [x] The description ends with a full stop/period
5. [x] The entry is ordered alphabetically in Productivity
6. [x] No OSS or Freeware icon applies because Nori is a commercial application with a free trial