### PR TITLE
Add LidRun to Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,7 @@
 - [Keka](https://www.keka.io/) - Compress to and extract from many archive file formats. ![Freeware][Freeware Icon]
 - [Knock](http://www.knocktounlock.com) - Unlock your Mac quickly and securely. ![Freeware][Freeware Icon]
 - [LaunchControl](http://www.soma-zone.com/LaunchControl/) - Create, manage and debug launchd services. ![Freeware][Freeware Icon]
+- [LidRun](https://lidrun.com) - Menu bar app that keeps your Mac awake with the lid closed for AI/dev agents (Claude Code, Cursor, Codex), with a battery floor and thermal auto-stop. ![Freeware][Freeware Icon]
 - [Loading](http://bonzaiapps.com) - See when apps are using your network in your Mac menubar. [![Open-Source Software][OSS Icon]](https://github.com/BonzaiThePenguin/Loading/) ![Freeware][Freeware Icon]
 - [Little Snitch](https://www.obdev.at/products/littlesnitch/index.html) - Protect your privacy.
 - [MacDown](http://macdown.uranusjr.com/) - Markdown editor. [![Open-Source Software][OSS Icon]](https://github.com/MacDownApp/macdown) ![Freeware][Freeware Icon]


### PR DESCRIPTION
Adds **[LidRun](https://lidrun.com)** to **Utilities** (alphabetical, after *LaunchControl*).

LidRun is a macOS menu-bar app that keeps a Mac awake with the lid closed so AI/dev agents (Claude Code, Cursor, Codex) and long builds keep running when you step away, then releases the Mac when the job's done or a battery/thermal threshold is crossed. It sits in the same niche as **KeepingYouAwake** and **Sleepless**, which this section already lists.

Free tier is free forever (optional paid Pro); closed-source, notarized DMG. Honest description, no superlatives.