### PR TITLE
Add AskClean to Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@
 - [APNGb](https://github.com/mancunianetz/APNGb) - .apng image assembler/disassembler app. [![Open-Source Software][OSS Icon]](https://github.com/mancunianetz/APNGb) ![Freeware][Freeware Icon]
 - [AppCleaner](http://freemacsoft.net/appcleaner/) - Uninstall your apps easily. ![Freeware][Freeware Icon]
 - [Artify](https://github.com/NghiaTranUIT/artify-macos) - A macOS X application for bringing dedicatedly 18th century Arts to everyone. [![Open-Source Software][OSS Icon]](https://github.com/NghiaTranUIT/artify-macos) ![Freeware][Freeware Icon]
+- [AskClean](https://www.askclean.app) - Native disk cleaner that explains each item before moving approved files to the Trash.
 - [Bartender](https://www.macbartender.com/) - Organize your menu bar apps.
 - [Batch Image Resizer](http://www.ironstarmedia.co.uk/resources/osx-image-resizer/) - Resize a large number of images quickly on your computer. ![Freeware][Freeware Icon]
 - [BeardedSpice](https://github.com/beardedspice/beardedspice) - Control web based media players with the media keys found on Mac keyboards. [![Open-Source Software][OSS Icon]](https://github.com/beardedspice/beardedspice) ![Freeware][Freeware Icon]


### PR DESCRIPTION
0. [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
1. [x] I confirm that I have read and understood the sections about "AI"-adjacent software. AskClean's primary purpose is native disk cleanup; AI supports item explanations rather than acting as a prompt, chatbot, or generative-tool interface.
2. [x] Project URL: https://www.askclean.app
3. [x] Why should this project be added: AskClean is a native macOS disk cleaner that explains scanned items before moving user-approved files to the Trash. The same download provides unlimited free scanning for validation, with a one-time purchase unlocking cleanup. It supports macOS 12 and later on Apple silicon and Intel Macs.
4. [x] End all descriptions with a full stop/period.
5. [x] Entry is ordered alphabetically.
6. [x] Appropriate icon(s) added if applicable (OSS, freeware). No icon applies because AskClean is a commercial, closed-source application.

Validation:

- Confirmed the entry appears once in the Utilities section between Artify and Bartender.
- Confirmed the product URL returns HTTP 200.
- Ran `git diff --check` successfully.

Previous submission: #935 was closed and locked without review comments. This resubmission follows the current PR template and updates the description to match the current product behavior.
