### PR TITLE
Add Cinesalve to Data Recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@
 ### Data Recovery
 
 - [Data Rescue](https://www.prosofteng.com/datarescue-mac-data-recovery/) - Comprehensive and professional data recovery for a multitude of scenarios.
+- [Cinesalve](https://cinesalve.honorboxx.workers.dev) - Rebuilds the missing index of a truncated MP4 or MOV so footage from a camera that lost power plays again.
 - [DiskWarrior](http://www.alsoft.com/DiskWarrior/) - Recover from filesystem corruptions when Disk Utility is out of options.
 
 


### PR DESCRIPTION
Adds Cinesalve to the Data Recovery section.

When a camera or recorder loses power mid-recording, every frame is on the card but the index was never written, so nothing will open the file. Cinesalve rebuilds that index using a healthy clip from the same camera as a reference.

- Native macOS app, universal binary, macOS 13+
- Runs entirely offline; nothing is uploaded
- Free to run and watch the recovered footage; a licence is only needed to save the repaired file

Measured against real camera footage, comparing every recovered frame to the original by byte offset and size: DJI Mavic 3 Pro 4K 722/722, GoPro HERO5-HERO8 / Karma / Fusion / MAX all exact, and QuickTime files written by Apple's own muxer 420/420.

Disclosure: I am the author. Placed alphabetically between Data Rescue and DiskWarrior. Happy to adjust the wording or move it if it fits better elsewhere.