### PR TITLE
Add Nexus Shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@
 - [Kaleidoscope](http://www.kaleidoscopeapp.com/) - Powerful diff and merge application supporting text, images, and folders.
 - [Knuff](https://github.com/KnuffApp/Knuff) - The debug application for Apple Push Notification Service (APNs). [![Open-Source Software][OSS Icon]](https://github.com/KnuffApp/Knuff) ![Freeware][Freeware Icon]
 - [Medis](https://getmedis.com) - A modern GUI for Redis.
+- [Nexus Shell](https://nexusshell.app/) - A native SSH and SFTP client with server monitoring, Docker management, and session logs.
 - [Pasteboard Viewer](https://apps.apple.com/app/id1499215709) - Inspect the system pasteboards. [![Open-Source Software][OSS Icon]](https://github.com/sindresorhus/Pasteboard-Viewer) ![Freeware][Freeware Icon]
 - [Paw](https://luckymarmot.com/paw) - The ultimate REST client.
 - [pgMagic](https://pgmagic.app) - A PostgreSQL client that lets you talk to your database in SQL or natural language.


### PR DESCRIPTION
0. [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
1. [x] I confirm that I have read and understood the sections about "AI"-adjacent software
2. [x] Project URL: https://nexusshell.app/
3. [x] Why should this project be added: Nexus Shell is a native SwiftUI SSH and SFTP client for Apple silicon Macs. It combines terminal sessions, file transfer, server monitoring, Docker management, and session logs. It is a commercial app with a standalone 7-day Pro trial, so maintainers can validate it without purchase. Its optional local MCP bridge is not the app's primary purpose; Nexus Shell is not an AI prompt wrapper.
4. [x] End all descriptions with a full stop/period
5. [x] Entry is ordered alphabetically
6. [x] Appropriate icon(s) added if applicable (OSS, freeware) - none apply because Nexus Shell is proprietary and freemium, not fully free.

Disclosure: I am the developer of Nexus Shell.
