### PR TITLE
Add ArtDeck to Graphics

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@
 - [Acorn](https://secure.flyingmeat.com/acorn/) - A very Mac-like image editor with a comprehensive feature set.
 - [Affinity Designer](https://affinity.serif.com/en-us/designer/) - Vector image design tool, possible Adobe Illustrator alternative.
 - [Affinity Photo](https://affinity.serif.com/en-us/photo/) - Raster image design tool, possible Adobe Photoshop alternative.
+- [ArtDeck](https://getartdeck.com) - Visual reference boards with tools for studying color, composition, and motion.
 - [GifCapture](https://github.com/onmyway133/GifCapture) - Record GIF screencasts. [![Open-Source Software][OSS Icon]](https://github.com/onmyway133/GifCapture)
 - [GIPHY Capture](https://itunes.apple.com/us/app/giphy-capture.-the-gif-maker/id668208984) - Capture and share GIFs on the desktop. ![Freeware][Freeware Icon]
 - [Image2icon](http://www.img2icnsapp.com) - Create and personalize icons from your pictures. ![Freeware][Freeware Icon]


### PR DESCRIPTION
0. [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
1. [x] I confirm that I have read and understood the sections about "AI"-adjacent software. ArtDeck has no generative AI features and is not a prompt wrapper.
2. [x] Project URL: https://getartdeck.com
3. [x] Why should this project be added: ArtDeck is a native visual reference board app for Mac, iPhone, and iPad, with tools for studying color, composition, and motion.
4. [x] The description ends with a full stop/period.
5. [x] The entry is ordered alphabetically in Graphics.
6. [x] No OSS or freeware icon applies because ArtDeck is a commercial, closed-source app.

ArtDeck is a one-time purchase. Maintainers can evaluate the Mac app through this public TestFlight build: https://testflight.apple.com/join/u89rRMxy

Disclosure: I am the developer of ArtDeck.

Validation:

- Confirmed the product and TestFlight URLs return HTTP 200.
- Confirmed the entry appears once and is ordered alphabetically.
- Ran `git diff --check` successfully.
- Ran the repository's `awesome_bot` check. The ArtDeck URL passed; the check still reports ten unrelated pre-existing broken links.
