### PR TITLE
Add Nocturne to Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,7 @@
 - [MonitorControl](https://github.com/MonitorControl/MonitorControl) - Control your display's brightness and volume on your Mac as if it was a native Apple Display. Use Apple Keyboard keys or custom shortcuts. Shows the native macOS OSDs. [![Open-Source Software][OSS Icon]](https://github.com/MonitorControl/MonitorControl)
 - [Monodraw](http://monodraw.helftone.com/) - A powerful ASCII art editor.
 - [Mounty](http://enjoygineering.com/mounty/) - A tiny tool to re-mount write-protected NTFS volumes under macOS 10.9+ in read-write mode.
+- [Nocturne](https://github.com/dotcomjack/nocturne) - Makes the menu bar clock unreadable so it stops telling you how late it is. [![Open-Source Software][OSS Icon]](https://github.com/dotcomjack/nocturne) ![Freeware][Freeware Icon]
 - [Noizio](http://noiz.io/) - Ambient sound equalizer for relaxation or productivity.
 - [Notational Velocity](http://notational.net/) - Store, retrieve and sync notes within a minimal GUI. [![Open-Source Software][OSS Icon]](https://github.com/scrod/nv/) ![Freeware][Freeware Icon]
 - [Noti](https://noti.center/) - Receive Android notifications on your mac (with PushBullet). [![Open-Source Software][OSS Icon]](https://github.com/jariz/Noti/) ![Freeware][Freeware Icon]


### PR DESCRIPTION
Adding [Nocturne](https://github.com/dotcomjack/nocturne), an MIT-licensed native macOS menu bar app.

The menu bar clock is the one menu bar item macOS ships no visibility toggle for, so Nocturne makes it unreadable rather than hidden: it flips `com.apple.menuextra.clock IsAnalog`, swapping the digital readout for a small analog dial. Useful if glancing at the time derails a late night session.

- One Apple preference key, no private APIs, no Accessibility or Screen Recording permissions
- Native Swift and SwiftUI, no dependencies
- Notarized and universal, macOS 14 or later

Placed alphabetically in Utilities, immediately before Noizio, following the existing entry format with the open source and freeware icons.