### PR TITLE
Add MistBar

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,7 @@
 - [Media Converter](http://media-converter.sourceforge.net/) - Simple (drag and drop) but advanced media conversion. [![Open-Source Software][OSS Icon]](https://sourceforge.net/p/media-converter/code/ci/master/tree/) ![Freeware][Freeware Icon]
 - [Menubar Colors](https://github.com/nvzqz/Menubar-Colors) - Convenient access to the system color panel. [![Open-Source Software][OSS Icon]](https://github.com/nvzqz/Menubar-Colors) ![Freeware][Freeware Icon]
 - [MenuMeters](http://member.ipmu.jp/yuji.tachikawa/MenuMetersElCapitan/) - A set of CPU, memory, disk, and network monitoring tools for macOS. [![Open-Source Software][OSS Icon]](https://github.com/yujitach/MenuMeters)
+- [MistBar](https://mistbar.app) - Hide and declutter your menu bar icons, with a built-in clipboard manager, mail, notes capture, and app launcher.
 - [MonitorControl](https://github.com/MonitorControl/MonitorControl) - Control your display's brightness and volume on your Mac as if it was a native Apple Display. Use Apple Keyboard keys or custom shortcuts. Shows the native macOS OSDs. [![Open-Source Software][OSS Icon]](https://github.com/MonitorControl/MonitorControl)
 - [Monodraw](http://monodraw.helftone.com/) - A powerful ASCII art editor.
 - [Mounty](http://enjoygineering.com/mounty/) - A tiny tool to re-mount write-protected NTFS volumes under macOS 10.9+ in read-write mode.


### PR DESCRIPTION
0. [x] I have read the Contribution Guidelines
1. [x] I confirm that I have read and understood the sections about "AI"-adjacent software
2. [x] Project URL: https://mistbar.app
3. [x] Why should this project be added: MistBar is a native macOS (AppKit) menu-bar utility — it hides/declutters menu-bar icons via Accessibility (not Screen Recording) and bundles a clipboard manager, mail, Apple Notes capture, and an app launcher. It belongs in Utilities alongside Bartender. Paid one-time purchase ($9.99 early-bird / $19.99) with a 14-day money-back guarantee, so it can be evaluated risk-free.
4. [x] End all descriptions with a full stop/period
5. [x] Entry is ordered alphabetically
6. [x] Appropriate icon(s) added if applicable — N/A (paid, closed-source, no App Store page; no badge, matching the Bartender entry)
