### PR TITLE
Add Plonk to Window Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,6 +362,7 @@
 - [Hummingbird](https://hummingbirdapp.site/) - Easily move and resize windows without mouse clicks, from anywhere within a window.
 - [Moom](https://manytricks.com/moom/) - Move and zoom windows, super light weight and customizable.
 - [Phoenix](https://github.com/kasper/phoenix) - A lightweight window and app manager scriptable with JavaScript. [![Open-Source Software][OSS Icon]](https://github.com/Hammerspoon/hammerspoon) ![Freeware][Freeware Icon]
+- [Plonk](https://ostapondo.github.io/Plonk/) - Snap zones you draw yourself, hotkeys, and workspaces that reopen your apps on the right monitor. [![Open-Source Software][OSS Icon]](https://github.com/ostapondo/plonk) ![Freeware][Freeware Icon]
 - [Rectangle](https://rectangleapp.com/) - Easily organize windows without using a mouse. [![Open-Source Software][OSS Icon]](https://github.com/rxhanson/Rectangle) ![Freeware][Freeware Icon]
 - [ShiftPlus](https://shiftplus.app/) - macOS workspace manager to switch workspaces, restore apps and windows across Spaces, monitors, and Macs in one click.
 - [Stay](https://cordlessdog.com/stay/) - Resize/position windows when displays change.


### PR DESCRIPTION
0. [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
1. [x] I confirm that I have read and understood the sections about "AI"-adjacent software. Plonk is a window manager. It also exposes its own commands over MCP, much as Lockpaw (already on the list) sits alongside agents — but there is no model in the app, no network call in any feature listed, and nothing here wraps an LLM. Zones, hotkeys, workspaces and OCR all run on the Mac with that interface switched off.
2. [x] Project URL: https://ostapondo.github.io/Plonk/ (source: https://github.com/ostapondo/plonk)
3. [x] Why should this project be added: zones are drawn per monitor rather than picked from presets, windows snap into them by drag or by `⌃⌥1`–`⌃⌥9`, and `⌃⌥0` restores the frame a window had before Plonk first touched it. Windows return to the monitor they were placed on after a display is unplugged and plugged back in, and workspaces save every window's frame and monitor, then rebuild the desk. Amethyst and yabai tile automatically; Rectangle and ShiftIt do halves and thirds. Nothing on the list currently does the drawn-grid approach. Open source (MIT), free, native Swift, no Electron, no accounts, no telemetry.
4. [x] End all descriptions with a full stop/period
5. [x] Entry is ordered alphabetically (between Phoenix and Rectangle)
6. [x] Appropriate icon(s) added if applicable (OSS, freeware)