### PR TITLE
Add VoxFlow - 100% On-Device AI Voice Dictation App for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@
 - [Plug](https://plugformac.com) - Discover and listen to music from Hype Machine. [![Open-Source Software][OSS Icon]](https://github.com/wulkano/Plug) ![Freeware][Freeware Icon]
 - [Recordia](https://sindresorhus.com/recordia) - Record audio directly from the menu bar or with a global keyboard shortcut.
 - [VOX Player](https://coppertino.com/vox/mac) - Play numerous lossy and lossless audio formats.
+- [VoxFlow](https://github.com/ameerhmz/VoxFlow) - Native, 100% on-device AI voice dictation app for macOS built with Apple Speech & FoundationModels. [![Open-Source Software][OSS Icon]](https://github.com/ameerhmz/VoxFlow) ![Freeware][Freeware Icon]
 - [XLD](http://tmkk.undo.jp/xld/index_e.html) - Rip/Decode/convert/play various "lossless" audio files. [![Open-Source Software][OSS Icon]](https://code.google.com/archive/p/xld/source) ![Freeware][Freeware Icon]
 
 ### Backup


### PR DESCRIPTION
Adds VoxFlow (https://github.com/ameerhmz/VoxFlow) to Audio section. VoxFlow is a native open-source macOS voice dictation app built with Apple Speech & FoundationModels.