### PR TITLE
Add Call Copilot to Command Line Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,6 +382,7 @@
 ## Command Line Utilities
 
 - [Awesome macOS Command Line](https://github.com/herrbischoff/awesome-osx-command-line) - Use your macOS terminal shell to do awesome things.
+- [Call Copilot](https://github.com/AnisurRahmann/call-copilot) - Records meeting audio (mic and system output via Core Audio taps) and transcribes it locally with faster-whisper into Markdown, with no cloud or API keys. [![Open-Source Software][OSS Icon]](https://github.com/AnisurRahmann/call-copilot) ![Freeware][Freeware Icon]
 - [CleanMyMac CLI](https://github.com/MacPaw/cleanmymac-cli) - Clean Xcode, Docker, Homebrew, and developer caches, analyze storage, and reclaim disk space from the terminal.
 - [m-cli](https://github.com/rgcr/m-cli) -  Swiss Army Knife for macOS.
 - [Mac-CLI](https://github.com/guarinogabriel/Mac-CLI) -  macOS command line tools for developers.


### PR DESCRIPTION
### What is Call Copilot?

[Call Copilot](https://github.com/AnisurRahmann/call-copilot) is a terminal command (`rec`) for macOS 14.2+ that records meeting audio — both the microphone and system output, captured directly via Apple's Core Audio process taps API (no BlackHole, no Multi-Output Device) — and transcribes it locally with faster-whisper into a clean Markdown transcript. No cloud, no API keys, no account; audio and transcripts never leave the machine.

Install via `brew install AnisurRahmann/tap/call-copilot` or `pipx install call-copilot`.

### Category

Added under **Command Line Utilities** — it is a CLI tool (`rec start` / `rec stop` / `rec list`).

### Guidelines checklist

- [x] Individual PR for a single suggestion
- [x] Title capitalized; description short, ends with a full stop
- [x] Alphabetical placement within the category (`Call Copilot` sits between `Awesome macOS Command Line` and `CleanMyMac CLI`)
- [x] OSS icon links to source, Freeware icon added (MIT licensed, no charge)
- [x] No referrer/tracking query strings
- [x] Not an Electron app
- [x] Not an AI prompt wrapper — transcription runs fully locally with faster-whisper (a specialised local ML model used as part of a recording workflow), which fits the list's stated exception. No LLM, chatbot, or generative-AI interface.