### PR TITLE
Add GI JI to Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@
 - [Dropzone](https://aptonic.com/) - Create a popup grid of customizable actions that enhance productivity on your Mac.
 - [f.lux](https://justgetflux.com/) - Automatically adjust your computer screen to match lighting. ![Freeware][Freeware Icon]
 - [Fantastical](https://flexibits.com/fantastical) - Complete Calendar app replacement which uses natural language for creating events.
+- [GI JI](https://giji.agency/) - Local-first knowledge workspace that answers from your documents with inspectable citations.
 - [Hazel](https://www.noodlesoft.com/hazel.php) - Create rules to automatically keep your files organized.
 - [HazeOver](https://hazeover.com/) - Turn distractions down and focus on your current task.
 - [HyperDock](https://bahoom.com/hyperdock/) - Select individual application window.


### PR DESCRIPTION
Adds GI JI (https://giji.agency), a local-first desktop knowledge workspace that answers from your documents with inspectable citations. Added alphabetically under Applications > Productivity. No open-source or freeware icon: GI JI is a commercial app with a free edition.

Disclosure: I am the developer.