### PR TITLE
Add Browser Cookie Bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@
 
 - [Anvil](http://anvilformac.com/) - Serve up static sites and Rack apps with simple URLs and zero configuration. ![Freeware][Freeware Icon]
 - [Base 2](http://menial.co.uk/base/) - A GUI for managing SQLite databases.
+- [Browser Cookie Bridge](https://cookiebridge.apoorvdarshan.com/) - Transfer authenticated Chromium sessions locally between supported browsers and automation tools. [![Open-Source Software][OSS Icon]](https://github.com/apoorvdarshan/browser-cookie-bridge) ![Freeware][Freeware Icon]
 - [CocoaRestClient](https://mmattozzi.github.io/cocoa-rest-client) - An app for testing REST endpoints. [![Open-Source Software][OSS Icon]](https://github.com/mmattozzi/cocoa-rest-client) ![Freeware][Freeware Icon]
 - [Cork](https://corkmac.app) - A fast, intuitive Homebrew GUI [![Open-Source Software][OSS Icon]](https://github.com/buresdv/Cork)
 - [Dash](https://kapeli.com/dash) - An API Documentation Browser and Code Snippet Manager.


### PR DESCRIPTION
0. [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
1. [x] I confirm that I have read and understood the sections about "AI"-adjacent software
2. [x] Project URL: https://cookiebridge.apoorvdarshan.com/
3. [x] Why should this project be added: Browser Cookie Bridge is a native, free, open-source developer utility for transferring authenticated Chromium sessions locally between supported browsers and browser-automation tools. It provides signed DMGs for Apple Silicon and Intel Macs, requires no Node.js or Xcode installation, and uses no cloud relay, account, or analytics.
4. [x] End all descriptions with a full stop/period
5. [x] Entry is ordered alphabetically
6. [x] Appropriate icon(s) added if applicable (OSS, freeware)