### PR TITLE
Add Persona

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,6 +390,7 @@
 - [Mocker](https://github.com/us/mocker) - Docker-compatible container CLI for macOS, built on Apple's Containerization framework. [![Open-Source Software][OSS Icon]](https://github.com/us/mocker) ![Freeware][Freeware Icon]
 - [mas](https://github.com/mas-cli/mas) - A CLI for the Mac App Store. [![Open-Source Software][OSS Icon]](https://github.com/mas-cli/mas) ![Freeware][Freeware Icon]
 - [quokka](https://github.com/dutradotdev/quokka) - Inspect and clean a USB-connected iPhone from the terminal. No jailbreak required. [![Open-Source Software][OSS Icon]](https://github.com/dutradotdev/quokka) ![Freeware][Freeware Icon]
+- [Persona](https://github.com/jayamitkatariya/personacli) - Local-first workspace with notes, tasks and AI chat, stored as plain markdown files. [![Open-Source Software][OSS Icon]](https://github.com/jayamitkatariya/personacli) ![Freeware][Freeware Icon]
 
 ## macOS Utilities
 


### PR DESCRIPTION
Persona is a local-first personal workspace for macOS: notes, tasks and AI chat, all stored as plain markdown files on your machine. No accounts, no cloud. Runs a lightweight local server and opens in your browser, plus a full CLI.

MIT licensed, open source.

Repo: https://github.com/jayamitkatariya/personacli