### PR TITLE
Add DueFlow to Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@
 - [ClipMenu](http://www.clipmenu.com/) - ClipBoard History Manager. [![Open-Source Software][OSS Icon]](https://github.com/naotaka/ClipMenu) ![Freeware][Freeware Icon]
 - [CloudClip](http://www.thinkbitz.com/cloudclip/) - Sync your clipboard between your Mac and your iOS devices. ![Freeware][Freeware Icon]
 - [Dropzone](https://aptonic.com/) - Create a popup grid of customizable actions that enhance productivity on your Mac.
+- [DueFlow](https://ustinian5.github.io/DueFlow/) - Turn deadline notices into reverse schedules, risk checks, and calendar exports locally. [![Open-Source Software][OSS Icon]](https://github.com/Ustinian5/DueFlow) ![Freeware][Freeware Icon]
 - [f.lux](https://justgetflux.com/) - Automatically adjust your computer screen to match lighting. ![Freeware][Freeware Icon]
 - [Fantastical](https://flexibits.com/fantastical) - Complete Calendar app replacement which uses natural language for creating events.
 - [Hazel](https://www.noodlesoft.com/hazel.php) - Create rules to automatically keep your files organized.


### PR DESCRIPTION
0. [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
1. [x] I confirm that I have read and understood the sections about "AI"-adjacent software. DueFlow is a local deadline-planning application with deterministic planning, risk checks, and calendar export; optional model extraction is one intake feature rather than the product's primary purpose.
2. [x] Project URL: https://ustinian5.github.io/DueFlow/
3. [x] Why should this project be added: DueFlow is a free, MIT-licensed Tauri macOS application that turns deadline notices into editable reverse schedules, risk checks, reminders, and calendar exports while keeping its workspace local.
4. [x] End all descriptions with a full stop/period
5. [x] Entry is ordered alphabetically
6. [x] Appropriate icon(s) added if applicable (OSS, freeware)

The entry uses the project site as the primary link and the OSS icon links to the source repository. DueFlow is built with Tauri rather than Electron.