### PR TITLE
Add NeoTiler to Window Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,6 +363,7 @@
 - [Hammerspoon](http://www.hammerspoon.org/) - Extremely powerful scripting engine for macOS. [![Open-Source Software][OSS Icon]](https://github.com/Hammerspoon/hammerspoon) ![Freeware][Freeware Icon]
 - [Hummingbird](https://hummingbirdapp.site/) - Easily move and resize windows without mouse clicks, from anywhere within a window.
 - [Moom](https://manytricks.com/moom/) - Move and zoom windows, super light weight and customizable.
+- [NeoTiler](https://getneotiler.com/) - A smart, drag-and-drop based window manager with dynamic snap zones for macOS.
 - [Phoenix](https://github.com/kasper/phoenix) - A lightweight window and app manager scriptable with JavaScript. [![Open-Source Software][OSS Icon]](https://github.com/Hammerspoon/hammerspoon) ![Freeware][Freeware Icon]
 - [Rectangle](https://rectangleapp.com/) - Easily organize windows without using a mouse. [![Open-Source Software][OSS Icon]](https://github.com/rxhanson/Rectangle) ![Freeware][Freeware Icon]
 - [ShiftPlus](https://shiftplus.app/) - macOS workspace manager to switch workspaces, restore apps and windows across Spaces, monitors, and Macs in one click.


### PR DESCRIPTION
Hi! I'd like to add **NeoTiler** to the Window Management section.

**NeoTiler** is a modern, drag-and-drop focused window manager for macOS with dynamic snap zones. It's a great alternative to Magnet and Rectangle with a fresh take on window management.

🔗 Website: https://getneotiler.com/

Thank you!