### PR TITLE
Add File Island

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,7 @@
 - [EtreCheck](http://etrecheck.com) - Output system information and configuration to get more informed help from Apple support professionals. ![Freeware][Freeware Icon]
 - [Equinox](https://equinoxmac.com) - Create macOS dynamic wallpapers. [![Open-Source Software][OSS Icon]](https://github.com/rlxone/Equinox) ![Freeware][Freeware Icon]
 - [Fanny](http://fannywidget.com/) - Notification Center widget and menu bar application to monitor your Mac's fans and CPU temperature. [![Open-Source Software][OSS Icon]](https://github.com/DanielStormApps/Fanny) ![Freeware][Freeware Icon]
+- [File Island](https://treafree.top/FileIsland/) - Convert images, video, and audio locally from the MacBook notch, including batch folders and drag-out results. ![Freeware][Freeware Icon]
 - [Finicky](https://johnste.github.io/finicky/) - App that allows you to set rules that decide which browser is opened for every link. [![Open-Source Software][OSS Icon]](https://github.com/johnste/finicky) ![Freeware][Freeware Icon]
 - [Flotato](https://flotato.com/) - Use any web site as a beautiful Mac app.
 - [Fluid](http://fluidapp.com/) - Turn web applications into Mac applications.


### PR DESCRIPTION
0. [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
1. [x] I confirm that I have read and understood the sections about "AI"-adjacent software
2. [x] Project URL: https://treafree.top/FileIsland/
3. [x] Why should this project be added: File Island is a native, freeware macOS utility for local image, video, and audio conversion. It supports mixed batch folders and lets users drag converted files directly from its result shelf.
4. [x] End all descriptions with a full stop/period
5. [x] Entry is ordered alphabetically
6. [x] Appropriate icon(s) added if applicable (OSS, freeware)

File Island is built with SwiftUI and AppKit. It is not an Electron application or an AI wrapper. The entry uses the Freeware icon only because the project is source-available under All Rights Reserved rather than an open-source license.
