### PR TITLE
Add Mongrel

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@
 - [Kaleidoscope](http://www.kaleidoscopeapp.com/) - Powerful diff and merge application supporting text, images, and folders.
 - [Knuff](https://github.com/KnuffApp/Knuff) - The debug application for Apple Push Notification Service (APNs). [![Open-Source Software][OSS Icon]](https://github.com/KnuffApp/Knuff) ![Freeware][Freeware Icon]
 - [Medis](https://getmedis.com) - A modern GUI for Redis.
+- [Mongrel](https://www.visorcraft.com/) - Database systems workbench for 30+ engines with terminals, SFTP, Docker, Kubernetes, and an API client. Runs natively on Apple silicon.
 - [Pasteboard Viewer](https://apps.apple.com/app/id1499215709) - Inspect the system pasteboards. [![Open-Source Software][OSS Icon]](https://github.com/sindresorhus/Pasteboard-Viewer) ![Freeware][Freeware Icon]
 - [Paw](https://luckymarmot.com/paw) - The ultimate REST client.
 - [pgMagic](https://pgmagic.app) - A PostgreSQL client that lets you talk to your database in SQL or natural language.


### PR DESCRIPTION
<!-- Thanks for contributing to awesome-macOS  -->

<!-- Please fill out the following: -->

0. [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
1. [x] I confirm that I have read and understood the sections about "AI"-adjacent software
2. [x] Project URL: https://www.visorcraft.com/
3. [x] Why should this project be added: Mongrel is a native macOS (Apple silicon) desktop database systems workbench supporting 30+ database engines, with built-in SSH/Mosh/Telnet/Serial terminals, SFTP/SCP file transfer, Docker/Podman and Kubernetes management, and an HTTP/GraphQL/WebSocket/gRPC API client. It is a Tauri v2/Rust application (not Electron). Disclosure: I am submitting on behalf of the vendor (VisorCraft). Mongrel is proprietary, paid software with a 7-day free trial available for maintainers to validate inclusion; its main purpose is database/terminal tooling, not interfacing with generative AI.
4. [x] End all descriptions with a full stop/period
5. [x] Entry is ordered alphabetically
6. [x] Appropriate icon(s) added if applicable (OSS, freeware) — none applicable: Mongrel is neither open-source nor freeware, so no icon was added.