### PR TITLE
Add Meeting Recorder to Audio

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@
 - [BackgroundMusic](https://github.com/kyleneideck/BackgroundMusic) - Record system audio, control audio levels for individual apps, and automatically pauses your music player when other audio starts playing and unpauses it afterwards. [![Open-Source Software][OSS Icon]](https://github.com/kyleneideck/BackgroundMusic) ![Freeware][Freeware Icon]
 - [Fader](https://fader.pantafive.dev) - Menu bar volume mixer with per-app volume, one-click audio output switching, and Bluetooth headphone control. [![Open-Source Software][OSS Icon]](https://github.com/pantafive/fader) ![Freeware][Freeware Icon]
 - [krisp](https://krisp.ai/) - AI-powered app that removes background noise and echo from meetings leaving only human voice.
+- [Meeting Recorder](https://gensoft.ge/meeting-recorder) - Records Zoom, Meet, Teams, and in-person meetings, then transcribes them and labels speakers entirely on-device.
 - [Murmur](https://murmurtts.com/) - On-device text-to-speech studio with 860+ voices, voice cloning, and four AI models running entirely on Apple Silicon via MLX.
 - [Plug](https://plugformac.com) - Discover and listen to music from Hype Machine. [![Open-Source Software][OSS Icon]](https://github.com/wulkano/Plug) ![Freeware][Freeware Icon]
 - [Recordia](https://sindresorhus.com/recordia) - Record audio directly from the menu bar or with a global keyboard shortcut.


### PR DESCRIPTION
0. [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
1. [x] I confirm that I have read and understood the sections about "AI"-adjacent software
2. [x] Project URL: https://gensoft.ge/meeting-recorder
3. [x] Why should this project be added:

   A native macOS menu-bar recorder for meetings. It captures Zoom, Meet and Teams calls via ScreenCaptureKit (system audio and mic as two separate tracks, so "You" and each speaker stay distinct), and also records in-person meetings from the mic alone. Transcription and speaker labelling then run on the machine: whisper.cpp `large-v3-turbo` with Silero VAD, and pyannote for diarization. Language is auto-detected across English, Russian and Hebrew.

   Existing entries in Audio cover capture (Audio Hijack, Recordia) or call audio cleanup (krisp); none of them turn a recorded meeting into an attributed transcript locally. The nearest well-known alternatives are cloud services that upload your meeting audio.

   On the "AI"-adjacent rules: this is not a prompt wrapper or an LLM front-end. What it depends on are local, specialised speech models — speech recognition and speaker diarization — used as part of the recording pipeline, which is the case the guidelines allow.

4. [x] End all descriptions with a full stop/period
5. [x] Entry is ordered alphabetically (between `krisp` and `Murmur`)
6. [x] Appropriate icon(s) added if applicable (OSS, freeware) — neither applies: it is closed-source and commercial. Per the guidelines on commercial apps, it ships a 14-day free trial with no account and no bundle requirement, so maintainers can validate it directly. It is a native AppKit app, not Electron.

Disclosure: I am affiliated with this app.