### PR TITLE
Add Filemorph to Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,7 @@
 - [EtreCheck](http://etrecheck.com) - Output system information and configuration to get more informed help from Apple support professionals. ![Freeware][Freeware Icon]
 - [Equinox](https://equinoxmac.com) - Create macOS dynamic wallpapers. [![Open-Source Software][OSS Icon]](https://github.com/rlxone/Equinox) ![Freeware][Freeware Icon]
 - [Fanny](http://fannywidget.com/) - Notification Center widget and menu bar application to monitor your Mac's fans and CPU temperature. [![Open-Source Software][OSS Icon]](https://github.com/DanielStormApps/Fanny) ![Freeware][Freeware Icon]
+- [Filemorph](https://filemorph.app) - Convert, compress and edit 80+ file formats fully on-device — nothing is ever uploaded.
 - [Finicky](https://johnste.github.io/finicky/) - App that allows you to set rules that decide which browser is opened for every link. [![Open-Source Software][OSS Icon]](https://github.com/johnste/finicky) ![Freeware][Freeware Icon]
 - [Flotato](https://flotato.com/) - Use any web site as a beautiful Mac app.
 - [Fluid](http://fluidapp.com/) - Turn web applications into Mac applications.


### PR DESCRIPTION
Adds [Filemorph](https://filemorph.app) to the Utilities section, alphabetically between Fanny and Finicky.

Filemorph is a native Swift app that converts, compresses and edits 80+ file formats — images, PDF, video, audio, documents and archives — fully on-device; nothing is ever uploaded and it works offline. Available on the Mac App Store (macOS 14+): https://apps.apple.com/us/app/filemorph-convert-edit/id6761300676?platform=mac

- Searched existing entries and PRs — not a duplicate
- One suggestion, alphabetical order kept, matches the list's entry format

**Disclosure:** I'm the developer of Filemorph.