### PR TITLE
Add Boiler to Video

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,7 @@
 
 ### Video
 
+- [Boiler](https://boiler.jejestudios.com) - Adds the hand-drawn line boil wobble of traditional animation to video. [![Open-Source Software][OSS Icon]](https://github.com/princezoho/zohoboil) ![Freeware][Freeware Icon]
 - [HandBrake](https://handbrake.fr/) - High performance video encoding and conversion tools with a nice GUI. [![Open-Source Software][OSS Icon]](https://github.com/HandBrake/HandBrake)
 - [IINA](https://lhc70000.github.io/iina/) - Media player with a minimalist design. [![Open-Source Software][OSS Icon]](https://github.com/lhc70000/iina) ![Freeware][Freeware Icon]
 - [mpv](https://mpv.io/) - Media player. [![Open-Source Software][OSS Icon]](https://github.com/mpv-player/mpv)


### PR DESCRIPTION
0. [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
1. [x] I confirm that I have read and understood the sections about "AI"-adjacent software
2. [x] Project URL: https://boiler.jejestudios.com (source: https://github.com/princezoho/zohoboil)
3. [x] Why should this project be added: It fills a gap in the Video section, which currently covers encoding, playback and subtitles but no effects. Boiler applies "line boil", the shimmer hand-drawn animation gets from every frame being redrawn slightly differently, to ordinary footage. It also does chromatic aberration and film grain. It is native (Python and pywebview, not Electron), MIT licensed, free with no paid tier, and signed and notarized by Apple so it runs without disabling Gatekeeper. No generative AI is involved; the effect is edge detection and displacement maps.
4. [x] End all descriptions with a full stop/period
5. [x] Entry is ordered alphabetically
6. [x] Appropriate icon(s) added if applicable (OSS, freeware)

Disclosure: I am the developer.