### PR TITLE
Add amtrino to Developers

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@
 
 ### Developers
 
+- [amtrino](https://github.com/arian-shamaei/amtrino) - Every AI coding session (Claude Code, Codex CLI) as a live identity-colored dot in the menu bar; notifications jump to the session's terminal. [![Open-Source Software][OSS Icon]](https://github.com/arian-shamaei/amtrino) ![Freeware][Freeware Icon]
 - [Anvil](http://anvilformac.com/) - Serve up static sites and Rack apps with simple URLs and zero configuration. ![Freeware][Freeware Icon]
 - [Base 2](http://menial.co.uk/base/) - A GUI for managing SQLite databases.
 - [CocoaRestClient](https://mmattozzi.github.io/cocoa-rest-client) - An app for testing REST endpoints. [![Open-Source Software][OSS Icon]](https://github.com/mmattozzi/cocoa-rest-client) ![Freeware][Freeware Icon]


### PR DESCRIPTION
Adds [amtrino](https://github.com/arian-shamaei/amtrino) — every AI coding session on the Mac (Claude Code, Codex CLI) as a breathing, identity-colored dot in a 3×3 menu bar grid: pulsing while the model responds, flashing when a response finishes, notifications clicking through to the session's exact tmux pane. Free, open source (MIT), notarized, Homebrew cask.

Alphabetical placement in Developers (before Anvil).

![the amtrino menu bar icon, live](https://raw.githubusercontent.com/arian-shamaei/amtrino/main/docs/assets/hero-icon.gif)