### PR TITLE
Add nowbar to Audio

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@
 - [BackgroundMusic](https://github.com/kyleneideck/BackgroundMusic) - Record system audio, control audio levels for individual apps, and automatically pauses your music player when other audio starts playing and unpauses it afterwards. [![Open-Source Software][OSS Icon]](https://github.com/kyleneideck/BackgroundMusic) ![Freeware][Freeware Icon]
 - [Fader](https://fader.pantafive.dev) - Menu bar volume mixer with per-app volume, one-click audio output switching, and Bluetooth headphone control. [![Open-Source Software][OSS Icon]](https://github.com/pantafive/fader) ![Freeware][Freeware Icon]
 - [krisp](https://krisp.ai/) - AI-powered app that removes background noise and echo from meetings leaving only human voice.
+- [nowbar](https://apps.apple.com/us/app/nowbar-album-art-menu-bar/id6798459887) - Live album art for the currently playing music as a menu bar item, replacing the static Now Playing glyph. [![Open-Source Software][OSS Icon]](https://github.com/arian-shamaei/nowbar) ![Freeware][Freeware Icon]
 - [Murmur](https://murmurtts.com/) - On-device text-to-speech studio with 860+ voices, voice cloning, and four AI models running entirely on Apple Silicon via MLX.
 - [Plug](https://plugformac.com) - Discover and listen to music from Hype Machine. [![Open-Source Software][OSS Icon]](https://github.com/wulkano/Plug) ![Freeware][Freeware Icon]
 - [Recordia](https://sindresorhus.com/recordia) - Record audio directly from the menu bar or with a global keyboard shortcut.


### PR DESCRIPTION
Adds [nowbar](https://github.com/arian-shamaei/nowbar) — live album art for the currently playing music as a macOS menu bar item, replacing the static Now Playing glyph. Free on the App Store, open source (MIT). Alphabetical placement in Audio; entry format matches (OSS + Freeware icons).

(Separate PR from #1010/amtrino so each can be reviewed independently.)