### PR TITLE
Add Zisla

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,7 @@
 - [Übersicht](http://tracesof.net/uebersicht/) - Run system commands and display their output on your desktop as widgets. [![Open-Source Software][OSS Icon]](https://github.com/felixhageloh/uebersicht) ![Freeware][Freeware Icon]
 - [The Unarchiver](https://theunarchiver.com/) - Unarchive many different kinds of archive files. ![Freeware][Freeware Icon]
 - [Wineskin](https://github.com/Gcenx/WineskinServer) - Run Windows applications and games on your Mac. [![Open-Source Software][OSS Icon]](https://github.com/Gcenx/WineskinServer) ![Freeware][Freeware Icon]
+- [Zisla](https://github.com/wzz6423/zisla) - Native macOS top workspace around the notch with media controls, file handoff, and system utilities. [![Open-Source Software][OSS Icon]](https://github.com/wzz6423/zisla) ![Freeware][Freeware Icon]
 
 ### Video
 


### PR DESCRIPTION
0. [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md).
1. [x] I confirm that I have read and understood the sections about "AI"-adjacent software.
2. Project URL: https://github.com/wzz6423/zisla
3. Why should this project be added: Zisla is a native SwiftUI top workspace around the notch. Its primary purpose is desktop utilities; it does not include a chat interface, model, or agent wrapper. Its optional local activity monitor only reports supported tool activity and does not read prompts or responses.
4. [x] End all descriptions with a full stop/period.
5. [x] Entry is ordered alphabetically.
6. [x] Appropriate icon(s) added if applicable (OSS, freeware).
