### PR TITLE
Add Spyglass to Finder

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@
 - [Path Finder](http://www.cocoatech.com/pathfinder/) - A powerful dual-pane browser alternative to Finder.
 - [Pathly](https://pathly.sophinauta.com/) - Copy any file or folder path from Finder: full, directory, URL, or Git-relative.
 - [Quicklook-Plugins](https://github.com/sindresorhus/quick-look-plugins) - List of extra quicklook plugins to enable previewing more filetypes in the Finder.
+- [Spyglass](https://magicelklabs.com/spyglass/) - Quick Look previews for Google Drive stub files, showing the document instead of the JSON that syncs to disk.
 - [TotalFinder](http://totalfinder.binaryage.com/) - A powerful alternative to Finder.
 - [XtraFinder](https://www.trankynam.com/xtrafinder/) - Adds useful features to Finder. ![Freeware][Freeware Icon]
 


### PR DESCRIPTION
Adds Spyglass to the Finder section, next to the Quicklook-Plugins entry.

When Google Drive for desktop syncs to a Mac, Docs and Sheets do not come down as real files. They arrive as small JSON stubs (`.gdoc`, `.gsheet`, `.gslides`, `.gdraw`, `.gform`, `.gsite`) that hold a document ID and nothing else, so pressing Space in Finder previews the JSON. Spyglass declares those file types and shows the document.

Placed alphabetically between Quicklook-Plugins and TotalFinder. It is a native Swift and SwiftUI app, and the rendered previews are a paid unlock, so I did not tag it Freeware.