### PR TITLE
Add Wandful to Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@
 - [Telephone](http://www.64characters.com/telephone/) - A SIP softphone. Make phone calls over the Internet or your company’s network. [![Open-Source Software][OSS Icon]](https://github.com/eofster/Telephone) ![Freeware][Freeware Icon]
 - [TextExpander](https://smilesoftware.com/textexpander) - Create custom keyboard shortcuts for frequently-used text and pictures.
 - [Timing](https://timingapp.com/) - Automatic time and productivity tracking for Mac. Helps you stay on track with your work and ensures no billable hours get lost if you are billing hourly.
+- [Wandful](https://ostapondo.github.io/wandful/) - Magic wand for the desktop: draw a rune with the mouse and it casts the keyboard shortcut you bound to it. [![Open-Source Software][OSS Icon]](https://github.com/ostapondo/wandful) ![Freeware][Freeware Icon]
 
 
 ### Sharing Files


### PR DESCRIPTION
0. [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
1. [x] I confirm that I have read and understood the sections about "AI"-adjacent software
2. [x] Project URL: https://github.com/ostapondo/wandful (site: https://ostapondo.github.io/wandful/)
3. [x] Why should this project be added: Wandful is a mouse-gesture launcher for keyboard shortcuts — summon a wand from the menu bar or a hotkey, draw a rune, and the shortcut bound to it is typed into the app you were in (or an app opens). It is a native Tauri 2 app (Rust + a small WebView UI, not Electron), MIT, no accounts or network, and complements BetterTouchTool / Karabiner already in Productivity with a shape-based, look-free trigger. Free builds for Apple silicon and Intel on the releases page and via Homebrew.
4. [x] End all descriptions with a full stop/period
5. [x] Entry is ordered alphabetically (after Timing)
6. [x] Appropriate icon(s) added if applicable (OSS, freeware)