### PR TITLE
Add FunNotch to Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,7 @@
 - [Finicky](https://johnste.github.io/finicky/) - App that allows you to set rules that decide which browser is opened for every link. [![Open-Source Software][OSS Icon]](https://github.com/johnste/finicky) ![Freeware][Freeware Icon]
 - [Flotato](https://flotato.com/) - Use any web site as a beautiful Mac app.
 - [Fluid](http://fluidapp.com/) - Turn web applications into Mac applications.
+- [FunNotch](https://github.com/JoshuaT1105/FunNotch) - Turns the MacBook notch into a hub for media controls, a drag-and-drop file shelf, clipboard history, focus sessions and twelve widgets. [![Open-Source Software][OSS Icon]](https://github.com/JoshuaT1105/FunNotch) ![Freeware][Freeware Icon]
 - [gfxCardStatus](https://gfx.io/) - Menu bar app to monitor and switch between integrated and discrete GPUs on MacBook Pro. [![Open-Source Software][OSS Icon]](https://github.com/codykrieger/gfxCardStatus) ![Freeware][Freeware Icon]
 - [Gray](https://github.com/zenangst/Gray) - Pick between the light appearance and the dark appearance on a per-app basis with the click of a button. [![Open-Source Software][OSS Icon]](https://github.com/zenangst/Gray) ![Freeware][Freeware Icon]
 - [Helium](https://github.com/JadenGeller/Helium) - A floating browser window that allows you to watch media while you work. [![Open-Source Software][OSS Icon]](https://github.com/JadenGeller/Helium) ![Freeware][Freeware Icon]


### PR DESCRIPTION
Adds **FunNotch** to *Utilities*, placed alphabetically between Fluid and gfxCardStatus.

```
- [FunNotch](https://github.com/JoshuaT1105/FunNotch) - Turns the MacBook notch into a hub for media controls, a drag-and-drop file shelf, clipboard history, focus sessions and twelve widgets. [![Open-Source Software][OSS Icon]](https://github.com/JoshuaT1105/FunNotch) ![Freeware][Freeware Icon]
```

- **Source:** https://github.com/JoshuaT1105/FunNotch
- **Licence:** GPL-3.0, so both the OSS and Freeware icons apply
- **Built with:** Swift and SwiftUI, no dependencies
- **Size:** 2.7 MB, universal binary (Apple Silicon and Intel)
- **Requirements:** macOS 14+
- No account, no telemetry

Checked the README for an existing entry first; there isn't one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)