### PR TITLE
Add Zmina to Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,7 @@
 - [Telephone](http://www.64characters.com/telephone/) - A SIP softphone. Make phone calls over the Internet or your company’s network. [![Open-Source Software][OSS Icon]](https://github.com/eofster/Telephone) ![Freeware][Freeware Icon]
 - [TextExpander](https://smilesoftware.com/textexpander) - Create custom keyboard shortcuts for frequently-used text and pictures.
 - [Timing](https://timingapp.com/) - Automatic time and productivity tracking for Mac. Helps you stay on track with your work and ensures no billable hours get lost if you are billing hourly.
+- [Zmina](https://zmina.app) - Clipboard manager that suggests actions based on the app you're pasting into.
 
 
 ### Sharing Files


### PR DESCRIPTION
0. [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
1. [x] I confirm that I have read and understood the sections about "AI"-adjacent software
2. [x] Project URL: https://zmina.app
3. [x] Why should this project be added:

Zmina is a clipboard manager whose suggestions depend on the app being pasted into, which is what separates it from the clipboard tools already listed. Copy a URL and it offers to strip the tracking parameters; copy a terminal snippet and it offers to wrap it as a code block for a chat app. It also keeps searchable history of everything copied, labelled by type.

Relevant to the guidelines specifically:

- **Not Electron.** It is built with Tauri (Rust host, system WebView).
- **Not "AI"-adjacent.** Classification and transforms are deterministic and run on-device. There is no LLM, no generative API, and no model call of any kind.
- **Commercial, with a free trial for validation:** 14 days, no account required, full app.
- No referrer or tracking parameters in the URL.

4. [x] End all descriptions with a full stop/period
5. [x] Entry is ordered alphabetically — appended after `Timing`, as nothing in Productivity sorts after "Zmina"
6. [x] Appropriate icon(s) added if applicable (OSS, freeware) — none apply; closed source and paid, so no OSS or Freeware icon, matching entries like TextExpander and Timing
