### PR TITLE
Add capkiku to Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@
 
 - [Alfred](https://www.alfredapp.com/) - Boosts your efficiency and productivity.
 - [BetterTouchTool](https://folivora.ai) - Configure gestures for mouse and actions for keyboard shortcuts.
-- [capkiku](https://capkiku.com) - Capture any screen region to reviewed Markdown via on-device Apple Vision OCR. ![Freeware][Freeware Icon]
+- [capkiku](https://capkiku.com) - Native menu bar app for region OCR with on-device Apple Vision, review/edit, Markdown save with frontmatter, and screenshot deletion. ![Freeware][Freeware Icon]
 - [ClipMenu](http://www.clipmenu.com/) - ClipBoard History Manager. [![Open-Source Software][OSS Icon]](https://github.com/naotaka/ClipMenu) ![Freeware][Freeware Icon]
 - [CloudClip](http://www.thinkbitz.com/cloudclip/) - Sync your clipboard between your Mac and your iOS devices. ![Freeware][Freeware Icon]
 - [Dropzone](https://aptonic.com/) - Create a popup grid of customizable actions that enhance productivity on your Mac.

--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@
 
 - [Alfred](https://www.alfredapp.com/) - Boosts your efficiency and productivity.
 - [BetterTouchTool](https://folivora.ai) - Configure gestures for mouse and actions for keyboard shortcuts.
+- [capkiku](https://capkiku.com) - Capture any screen region to reviewed Markdown via on-device Apple Vision OCR. ![Freeware][Freeware Icon]
 - [ClipMenu](http://www.clipmenu.com/) - ClipBoard History Manager. [![Open-Source Software][OSS Icon]](https://github.com/naotaka/ClipMenu) ![Freeware][Freeware Icon]
 - [CloudClip](http://www.thinkbitz.com/cloudclip/) - Sync your clipboard between your Mac and your iOS devices. ![Freeware][Freeware Icon]
 - [Dropzone](https://aptonic.com/) - Create a popup grid of customizable actions that enhance productivity on your Mac.

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@
 
 - [Alfred](https://www.alfredapp.com/) - Boosts your efficiency and productivity.
 - [BetterTouchTool](https://folivora.ai) - Configure gestures for mouse and actions for keyboard shortcuts.
-- [capkiku](https://capkiku.com) - Native menu bar app for region OCR with on-device Apple Vision, review/edit, Markdown save with frontmatter, and screenshot deletion. ![Freeware][Freeware Icon]
+- [capkiku](https://capkiku.com) - Native menu bar app that turns a selected screen region into editable Markdown using on-device Apple Vision OCR, then deletes the screenshot after saving. ![Freeware][Freeware Icon]
 - [ClipMenu](http://www.clipmenu.com/) - ClipBoard History Manager. [![Open-Source Software][OSS Icon]](https://github.com/naotaka/ClipMenu) ![Freeware][Freeware Icon]
 - [CloudClip](http://www.thinkbitz.com/cloudclip/) - Sync your clipboard between your Mac and your iOS devices. ![Freeware][Freeware Icon]
 - [Dropzone](https://aptonic.com/) - Create a popup grid of customizable actions that enhance productivity on your Mac.

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@
 
 - [Alfred](https://www.alfredapp.com/) - Boosts your efficiency and productivity.
 - [BetterTouchTool](https://folivora.ai) - Configure gestures for mouse and actions for keyboard shortcuts.
-- [capkiku](https://capkiku.com) - Native menu bar app that turns a selected screen region into editable Markdown using on-device Apple Vision OCR, then deletes the screenshot after saving. ![Freeware][Freeware Icon]
+- [capkiku](https://capkiku.com) - Menu bar app that turns a selected screen region into editable Markdown using on-device Apple Vision OCR, then deletes the screenshot after saving. ![Freeware][Freeware Icon]
 - [ClipMenu](http://www.clipmenu.com/) - ClipBoard History Manager. [![Open-Source Software][OSS Icon]](https://github.com/naotaka/ClipMenu) ![Freeware][Freeware Icon]
 - [CloudClip](http://www.thinkbitz.com/cloudclip/) - Sync your clipboard between your Mac and your iOS devices. ![Freeware][Freeware Icon]
 - [Dropzone](https://aptonic.com/) - Create a popup grid of customizable actions that enhance productivity on your Mac.


### PR DESCRIPTION
<!-- Thanks for contributing to awesome-macOS  -->

<!-- Please fill out the following: -->

0. [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
1. [x] I confirm that I have read and understood the sections about "AI"-adjacent software
2. [x] Project URL: https://capkiku.com
3. [x] Why should this project be added: Freeware macOS menu-bar app. Specialised on-device Apple Vision OCR inside a capture/review/save workflow, not an AI prompt wrapper. No account, no upload.
4. [x] End all descriptions with a full stop/period
5. [x] Entry is ordered alphabetically (Productivity, after BetterTouchTool, before ClipMenu)
6. [x] Appropriate icon(s) added if applicable (OSS, freeware): Freeware only; closed source so no OSS icon
