### PR TITLE
Add Plainsay to Audio

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@
 - [Fader](https://fader.pantafive.dev) - Menu bar volume mixer with per-app volume, one-click audio output switching, and Bluetooth headphone control. [![Open-Source Software][OSS Icon]](https://github.com/pantafive/fader) ![Freeware][Freeware Icon]
 - [krisp](https://krisp.ai/) - AI-powered app that removes background noise and echo from meetings leaving only human voice.
 - [Murmur](https://murmurtts.com/) - On-device text-to-speech studio with 860+ voices, voice cloning, and four AI models running entirely on Apple Silicon via MLX.
+- [Plainsay](https://plainsay.app/) - Dictation that transcribes on-device with Whisper or Parakeet, with an optional cleanup pass using a key you control. [![Open-Source Software][OSS Icon]](https://github.com/conrader/plainsay) ![Freeware][Freeware Icon]
 - [Plug](https://plugformac.com) - Discover and listen to music from Hype Machine. [![Open-Source Software][OSS Icon]](https://github.com/wulkano/Plug) ![Freeware][Freeware Icon]
 - [Recordia](https://sindresorhus.com/recordia) - Record audio directly from the menu bar or with a global keyboard shortcut.
 - [VOX Player](https://coppertino.com/vox/mac) - Play numerous lossy and lossless audio formats.


### PR DESCRIPTION
Adds [Plainsay](https://plainsay.app/) to the Audio section, in alphabetical order between Murmur and Plug.

An MIT-licensed macOS dictation app: hold a hotkey, speak, release, and the text lands wherever the cursor is. Transcription runs on-device through WhisperKit or NVIDIA Parakeet (Core ML / Neural Engine), so audio never leaves the Mac. An optional cleanup pass turns spoken language into written language using an API key the user controls — no account or subscription needed for the on-device path.

Source: https://github.com/conrader/plainsay