### PR TITLE
Add ScreenSage Pro

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,7 @@
 - [IINA](https://lhc70000.github.io/iina/) - Media player with a minimalist design. [![Open-Source Software][OSS Icon]](https://github.com/lhc70000/iina) ![Freeware][Freeware Icon]
 - [mpv](https://mpv.io/) - Media player. [![Open-Source Software][OSS Icon]](https://github.com/mpv-player/mpv)
 - [ScreenFlow](http://www.telestream.net/screenflow/) - Screencasting and video editing software.
+- [ScreenSage Pro](https://screensage.pro/) - Native macOS screen recorder and tutorial maker with automatic zoom, dynamic layouts, and built-in video editing.
 - [Subler](https://bitbucket.org/galad87/subler/wiki/Home) - Mux and tag MP4 files. [![Open-Source Software][OSS Icon]](https://bitbucket.org/galad87/subler/wiki/Home) ![Freeware][Freeware Icon]
 - [Subtitlr](http://lucija.frkovic.me/Subtitlr/) - Drag and drop subititle download utility. [![Open-Source Software][OSS Icon]](https://github.com/spilja/Subtitlr/tree/master)
 


### PR DESCRIPTION
0. [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
1. [x] I confirm that I have read and understood the sections about "AI"-adjacent software
2. [x] Project URL: https://screensage.pro/
3. [x] Why should this project be added: ScreenSage Pro is a native macOS screen recorder and tutorial maker for creating product demos and tutorials. It offers a direct free version/trial from its website, and its core workflow is screen recording and video editing rather than an AI prompt wrapper.
4. [x] End all descriptions with a full stop/period
5. [x] Entry is ordered alphabetically
6. [x] Appropriate icon(s) added if applicable (OSS, freeware) — not applicable; ScreenSage Pro is commercial software.
